### PR TITLE
Fix #135: Hide legends in detail charts

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -242,6 +242,7 @@ function AppContent() {
                 }}
                 dataKey="renewableShare"
                 showRegionalLine={isValidPostalCode(debouncedPostalCode) && hasRegionalData}
+                showLegend={false}
               />
             </ChartDetailView>
 
@@ -320,6 +321,7 @@ function AppContent() {
                   interpolated: t.interpolated,
                 }}
                 gridFees={gridFees}
+                showLegend={false}
               />
             </ChartDetailView>
 

--- a/components/charts/PriceBarChart.tsx
+++ b/components/charts/PriceBarChart.tsx
@@ -29,6 +29,7 @@ interface PriceBarChartProps {
   };
   interactionHint?: string;
   gridFees?: number;
+  showLegend?: boolean;
 }
 
 export function PriceBarChart({
@@ -42,6 +43,7 @@ export function PriceBarChart({
   labels,
   interactionHint,
   gridFees = GRID_FEES_AND_TAXES,
+  showLegend = true,
 }: PriceBarChartProps) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
 
@@ -240,8 +242,8 @@ export function PriceBarChart({
             </Text>
           )}
         </View>
-        {/* Legend - hidden on small devices in portrait mode */}
-        {!(isPhone && !isLandscape) && (
+        {/* Legend - hidden when showLegend is false or on small devices in portrait mode */}
+        {showLegend && !(isPhone && !isLandscape) && (
           <View style={{
             flexDirection: 'row',
             gap: 12,

--- a/components/charts/RenewableBarChart.tsx
+++ b/components/charts/RenewableBarChart.tsx
@@ -34,6 +34,7 @@ interface RenewableBarChartProps {
   interactionHint?: string;
   dataKey?: RenewableDataKey;
   showRegionalLine?: boolean; // Zeigt gestrichelte Linie für regionale Daten
+  showLegend?: boolean;
 }
 
 export function RenewableBarChart({
@@ -48,6 +49,7 @@ export function RenewableBarChart({
   interactionHint,
   dataKey = 'renewableShare',
   showRegionalLine = false,
+  showLegend = true,
 }: RenewableBarChartProps) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
 
@@ -201,8 +203,8 @@ export function RenewableBarChart({
             </Text>
           )}
         </View>
-        {/* Legend - hidden on small devices in portrait mode */}
-        {!(isPhone && !isLandscape) && (
+        {/* Legend - hidden when showLegend is false or on small devices in portrait mode */}
+        {showLegend && !(isPhone && !isLandscape) && (
           <View style={{
             flexDirection: 'row',
             gap: 12,


### PR DESCRIPTION
## Summary
- Add `showLegend` prop to PriceBarChart and RenewableBarChart components
- Legends now hidden on detail pages by setting `showLegend={false}`
- Legends still appear in main view when landscape or on larger devices
- Maintains existing portrait mode legend hiding on small devices in main view

## Test plan
- [ ] Open detail view for price chart - verify no legend in chart area
- [ ] Open detail view for renewable chart - verify no legend in chart area  
- [ ] Open main view on phone portrait - verify no legend (existing behavior)
- [ ] Open main view on phone landscape - verify legend appears
- [ ] Verify legend appears below charts on detail pages (existing behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)