### PR TITLE
Fix #158: Enable landscape mode for mobile app

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "Energy Prices Germany",
     "slug": "Energy_Price_Germany",
     "version": "1.3.0",
-    "orientation": "portrait",
+    "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
     "newArchEnabled": true,


### PR DESCRIPTION
## Summary
- Fixed landscape mode support for the mobile app by changing orientation setting from `portrait` to `default` in app.json
- This allows the app to rotate based on device orientation
- Web version already worked correctly (orientation setting doesn't affect web platforms)

## Changes
- Updated `orientation` property in [app.json:6](app.json#L6) from `"portrait"` to `"default"`

## Issue
Closes #158

## Testing
- The orientation setting now allows both portrait and landscape modes on mobile devices
- No changes to web functionality (already working)
- App will automatically adapt to device orientation

## Impact
- Mobile users can now use the app in landscape mode
- Improved user experience, especially on tablets and when viewing charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)