### PR TITLE
Fix #126: Eye Candy - Price zone bands and runner band

### DIFF
--- a/components/charts/PriceBarChart.tsx
+++ b/components/charts/PriceBarChart.tsx
@@ -279,6 +279,38 @@ function PriceBarChartComponent({
 
         {/* Bars (SVG) - Using pre-calculated bar data for performance */}
         <Svg width={chartWidth} height={chartHeight}>
+          {/* Price Zone Bands - subtle background color zones */}
+          {(() => {
+            const chartAreaHeight = chartHeight - padding - bottomPadding;
+            const chartAreaWidth = chartWidth - leftPadding - rightPadding;
+            // Price thresholds in ct/kWh (total price including grid fees)
+            const zones = [
+              { max: 25, color: '#4CAF50' },  // green: cheap
+              { max: 35, color: '#FFC107' },  // yellow: moderate
+              { max: 50, color: '#FF9800' },  // orange: expensive
+            ];
+            return zones.map((zone, i) => {
+              const zoneMin = i === 0 ? min : zones[i - 1].max;
+              const zoneMax = zone.max;
+              if (zoneMin >= maxTotal || zoneMax <= min) return null;
+              const clampedMin = Math.max(zoneMin, min);
+              const clampedMax = Math.min(zoneMax, maxTotal);
+              const yBottom = chartHeight - bottomPadding - ((clampedMin - min) / range) * chartAreaHeight;
+              const yTop = chartHeight - bottomPadding - ((clampedMax - min) / range) * chartAreaHeight;
+              return (
+                <Rect
+                  key={`zone-${i}`}
+                  x={leftPadding}
+                  y={yTop}
+                  width={chartAreaWidth}
+                  height={yBottom - yTop}
+                  fill={zone.color}
+                  opacity={0.06}
+                />
+              );
+            });
+          })()}
+
           {barData.map((bar) => {
             // Render dashed placeholder for missing data
             if (bar.marketPrice === null) {
@@ -327,6 +359,28 @@ function PriceBarChartComponent({
               </React.Fragment>
             );
           })}
+
+          {/* Runner Band - highlights current price level */}
+          {now >= minTime && now <= maxTime && (() => {
+            const currentBar = barData.find(b =>
+              b.marketPrice !== null &&
+              Math.abs(data[b.index].timestamp - now) <= 15 * 60 * 1000
+            );
+            if (!currentBar || currentBar.marketPrice === null) return null;
+            const bandHeight = 4;
+            const priceY = chartHeight - bottomPadding - ((currentBar.marketPrice - min) / range) * (chartHeight - padding - bottomPadding);
+            return (
+              <Rect
+                x={leftPadding}
+                y={priceY - bandHeight / 2}
+                width={chartWidth - leftPadding - rightPadding}
+                height={bandHeight}
+                fill={currentBar.color}
+                opacity={0.25}
+                rx={2}
+              />
+            );
+          })()}
 
           {/* Durchschnittslinie */}
           <Line

--- a/components/charts/RenewableBarChart.tsx
+++ b/components/charts/RenewableBarChart.tsx
@@ -265,6 +265,32 @@ function RenewableBarChartComponent({
 
         {/* Bars (SVG) - Using pre-calculated bar data for performance */}
         <Svg width={chartWidth} height={chartHeight}>
+          {/* Renewable Zone Bands - subtle background zones */}
+          {(() => {
+            const chartAreaHeight = chartHeight - padding - bottomPadding;
+            const chartAreaWidth = chartWidth - leftPadding - rightPadding;
+            const zones = [
+              { min: 0, max: 50, color: '#F44336' },   // red: low renewable
+              { min: 50, max: 80, color: '#FFC107' },   // yellow: moderate
+              { min: 80, max: 100, color: '#4CAF50' },  // green: high renewable
+            ];
+            return zones.map((zone, i) => {
+              const yBottom = chartHeight - bottomPadding - ((zone.min - min) / range) * chartAreaHeight;
+              const yTop = chartHeight - bottomPadding - ((zone.max - min) / range) * chartAreaHeight;
+              return (
+                <Rect
+                  key={`zone-${i}`}
+                  x={leftPadding}
+                  y={yTop}
+                  width={chartAreaWidth}
+                  height={yBottom - yTop}
+                  fill={zone.color}
+                  opacity={0.06}
+                />
+              );
+            });
+          })()}
+
           {barData.map((bar) => {
             // Render gray fading bar for missing data
             if (bar.value === null) {
@@ -352,6 +378,28 @@ function RenewableBarChartComponent({
               />
             );
           })}
+
+          {/* Runner Band - highlights current renewable share level */}
+          {now >= minTime && now <= maxTime && (() => {
+            const currentBar = barData.find(b =>
+              b.value !== null &&
+              Math.abs(data[b.index].timestamp - now) <= 15 * 60 * 1000
+            );
+            if (!currentBar || currentBar.value === null) return null;
+            const bandHeight = 4;
+            const valueY = chartHeight - bottomPadding - ((currentBar.value - min) / range) * (chartHeight - padding - bottomPadding);
+            return (
+              <Rect
+                x={leftPadding}
+                y={valueY - bandHeight / 2}
+                width={chartWidth - leftPadding - rightPadding}
+                height={bandHeight}
+                fill={currentBar.color}
+                opacity={0.25}
+                rx={2}
+              />
+            );
+          })()}
 
           {/* Durchschnittslinie */}
           <Line


### PR DESCRIPTION
## Summary
- Add subtle colored **price zone bands** as background in PriceBarChart (green <25¢, yellow 25-35¢, orange 35-50¢)
- Add subtle colored **renewable zone bands** in RenewableBarChart (red <50%, yellow 50-80%, green >80%)
- Add **runner band**: a horizontal highlight at the current price/renewable level, visually connecting the "now" marker to the Y-axis

All effects are very subtle (6% opacity for zones, 25% for runner band) to enhance readability without being distracting.

## Test plan
- [ ] Verify zone bands are visible but subtle in PriceBarChart
- [ ] Verify zone bands are visible but subtle in RenewableBarChart
- [ ] Verify runner band appears at correct price level for current time
- [ ] Verify both dark and light theme work well
- [ ] Test on phone and tablet screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)