### PR TITLE
chore: Disable auto-sync main → testing

### DIFF
--- a/.github/workflows/sync-testing.yml
+++ b/.github/workflows/sync-testing.yml
@@ -1,9 +1,9 @@
 name: Sync Testing Branch
 
 on:
-  # Automatic trigger when main branch is updated
-  push:
-    branches: [ main ]
+  # Automatic trigger disabled – sync is done manually
+  # push:
+  #   branches: [ main ]
   # Allow manual trigger
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- Deactivates the automatic push trigger that synced `main` → `testing` on every push to main
- Sync is now done manually via `workflow_dispatch` only
- Prevents unwanted merge commits cluttering the `testing` branch history

## Why
The auto-sync created noise in the `testing` branch and made it harder to track actual feature work. Manual sync gives better control over when `testing` is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)