### PR TITLE
feat: Animate chart cards and tooltips on mount (Fix #68)

### DIFF
--- a/components/charts/shared/ChartCard.tsx
+++ b/components/charts/shared/ChartCard.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { useRef, useEffect } from 'react';
 import type { ViewStyle } from 'react-native';
-import { View } from 'react-native';
+import { Animated, Easing } from 'react-native';
 
 interface ChartCardProps {
   backgroundColor: string;
@@ -8,6 +8,7 @@ interface ChartCardProps {
   cardPadding: number;
   children: React.ReactNode;
   style?: ViewStyle;
+  animateIn?: boolean;
 }
 
 function ChartCardComponent({
@@ -16,10 +17,24 @@ function ChartCardComponent({
   cardPadding,
   children,
   style,
+  animateIn = true,
 }: ChartCardProps) {
+  const opacity = useRef(new Animated.Value(animateIn ? 0 : 1)).current;
+
+  useEffect(() => {
+    if (!animateIn) return;
+    Animated.timing(opacity, {
+      toValue: 1,
+      duration: 400,
+      easing: Easing.out(Easing.ease),
+      useNativeDriver: true,
+    }).start();
+  }, [animateIn, opacity]);
+
   return (
-    <View
+    <Animated.View
       style={{
+        opacity,
         backgroundColor,
         margin,
         padding: cardPadding,
@@ -34,7 +49,7 @@ function ChartCardComponent({
       }}
     >
       {children}
-    </View>
+    </Animated.View>
   );
 }
 

--- a/components/charts/shared/ChartTooltip.tsx
+++ b/components/charts/shared/ChartTooltip.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { View, Platform } from 'react-native';
+import React, { useRef, useEffect } from 'react';
+import { Animated, Easing, Platform } from 'react-native';
 import type { ThemeColors } from '../../../utils/theme';
 
 interface ChartTooltipProps {
@@ -20,10 +20,22 @@ function ChartTooltipComponent({
   minWidth,
 }: ChartTooltipProps) {
   const tooltipBgColor = backgroundColor === colors.surface ? colors.background : colors.surface;
+  const opacity = useRef(new Animated.Value(0)).current;
+
+  useEffect(() => {
+    opacity.setValue(0);
+    Animated.timing(opacity, {
+      toValue: 1,
+      duration: 150,
+      easing: Easing.out(Easing.ease),
+      useNativeDriver: true,
+    }).start();
+  }, [opacity, tooltipLeft]);
 
   return (
-    <View
+    <Animated.View
       style={{
+        opacity,
         paddingVertical: 6,
         paddingHorizontal: 12,
         backgroundColor: tooltipBgColor,
@@ -46,7 +58,7 @@ function ChartTooltipComponent({
       }}
     >
       {children}
-    </View>
+    </Animated.View>
   );
 }
 


### PR DESCRIPTION
## Summary
- ChartCard fades in (opacity 0→1, 400ms) when it mounts – all three charts animate smoothly on load
- ChartTooltip fades in (150ms) whenever it appears or moves to a new bar/point
- New optional `animateIn` prop on ChartCard (default: `true`) for opt-out

## Implementation
- Uses React Native's built-in `Animated` API + `Easing` – no new dependencies
- `useNativeDriver: true` for GPU-accelerated animation on mobile
- Works on web via the same API

## Test plan
- [x] All 222 tests pass
- [ ] Open app locally, charts fade in on load
- [ ] Tap/hover a bar → tooltip fades in smoothly
- [ ] Dark and light mode both look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)