### PR TITLE
fix: Add animation cleanup to prevent memory leaks

### DIFF
--- a/components/charts/shared/ChartCard.tsx
+++ b/components/charts/shared/ChartCard.tsx
@@ -23,13 +23,22 @@ function ChartCardComponent({
 
   useEffect(() => {
     if (!animateIn) return;
-    Animated.timing(opacity, {
+
+    const animation = Animated.timing(opacity, {
       toValue: 1,
       duration: 400,
       easing: Easing.out(Easing.ease),
       useNativeDriver: true,
-    }).start();
-  }, [animateIn, opacity]);
+    });
+
+    animation.start();
+
+    return () => {
+      animation.stop();
+    };
+    // opacity is a stable Animated.Value ref – intentionally excluded
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [animateIn]);
 
   return (
     <Animated.View

--- a/components/charts/shared/ChartTooltip.tsx
+++ b/components/charts/shared/ChartTooltip.tsx
@@ -21,16 +21,34 @@ function ChartTooltipComponent({
 }: ChartTooltipProps) {
   const tooltipBgColor = backgroundColor === colors.surface ? colors.background : colors.surface;
   const opacity = useRef(new Animated.Value(0)).current;
+  const animationRef = useRef<Animated.CompositeAnimation | null>(null);
 
   useEffect(() => {
     opacity.setValue(0);
-    Animated.timing(opacity, {
+
+    if (animationRef.current) {
+      animationRef.current.stop();
+    }
+
+    const animation = Animated.timing(opacity, {
       toValue: 1,
       duration: 150,
       easing: Easing.out(Easing.ease),
       useNativeDriver: true,
-    }).start();
-  }, [opacity, tooltipLeft]);
+    });
+
+    animationRef.current = animation;
+    animation.start();
+
+    return () => {
+      if (animationRef.current) {
+        animationRef.current.stop();
+        animationRef.current = null;
+      }
+    };
+    // opacity is a stable Animated.Value ref – intentionally excluded
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tooltipLeft]);
 
   return (
     <Animated.View


### PR DESCRIPTION
## Summary
Addresses the 4 review suggestions from PR #187 (Copilot review).

**ChartCard:**
- Store animation in local variable and call `.stop()` in cleanup function
- Remove `opacity` from useEffect deps (stable `useRef` value, Copilot suggestion)

**ChartTooltip:**
- Use `animationRef` to cancel any ongoing animation before starting a new one
- Call `.stop()` + clear ref on unmount and when `tooltipLeft` changes
- Remove `opacity` from useEffect deps (stable `useRef` value, Copilot suggestion)

## Why
Without cleanup, animations that complete after unmount trigger React's "update on unmounted component" warning and may cause memory leaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)