### PR TITLE
fix: ClockChart label positioning and remove RenewableBarChart zone bands

### DIFF
--- a/components/charts/ClockChart.tsx
+++ b/components/charts/ClockChart.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, useCallback } from 'react';
 import { View, Text, Platform } from 'react-native';
-import Svg, { Path, Circle, Line, G } from 'react-native-svg';
+import Svg, { Path, Circle, Line, G, Text as SvgText } from 'react-native-svg';
 import type { ThemeColors } from '../../utils/theme';
 import { getPriceColor } from '../../utils/chartHelpers';
 import { useChartDimensions } from '../../utils/chartUtils';
@@ -125,11 +125,13 @@ function ClockChartComponent({
 
   // Chart geometry
   const size = Math.min(chartWidth - cardPadding * 2, isPhone ? 280 : 340);
-  const cx = size / 2;
-  const cy = size / 2;
+  const labelMargin = 20; // extra canvas space so SVG labels are not clipped
+  const svgSize = size + labelMargin * 2;
+  const cx = svgSize / 2;
+  const cy = svgSize / 2;
   const outerR = size / 2 - 8;
   const innerR = outerR * 0.55;
-  const labelR = outerR * 1.12;
+  const labelR = outerR * 1.18;
 
   const selectedSegment = selectedHour !== null ? hourSegments[selectedHour] : null;
   const currentSegment = hourSegments[currentHour];
@@ -187,7 +189,7 @@ function ClockChartComponent({
 
       {/* Clock SVG */}
       <View style={{ alignItems: 'center' }}>
-        <Svg width={size} height={size}>
+        <Svg width={svgSize} height={svgSize}>
           {/* Background circle */}
           <Circle cx={cx} cy={cy} r={outerR + 4} fill={colors.gridLine} opacity={0.1} />
 
@@ -245,30 +247,26 @@ function ClockChartComponent({
             );
           })()}
           <Circle cx={cx} cy={cy} r={4} fill={textColor} opacity={0.9} />
-        </Svg>
 
-        {/* Hour labels overlaid outside SVG (avoids RN-SVG Text limitations) */}
-        {clockLabels.map(h => {
-          const angle = (h / 24) * 360;
-          const pos = polarToCartesian(cx, cy, labelR, angle);
-          return (
-            <Text
-              key={`ol-${h}`}
-              style={{
-                position: 'absolute',
-                left: pos.x - 10,
-                top: pos.y - 7,
-                fontSize: isPhone ? 9 : 10,
-                color: textColor,
-                opacity: 0.55,
-                textAlign: 'center',
-                width: 20,
-              }}
-            >
-              {h}h
-            </Text>
-          );
-        })}
+          {/* Hour labels inside SVG – correct coordinate system */}
+          {clockLabels.map(h => {
+            const angle = (h / 24) * 360;
+            const pos = polarToCartesian(cx, cy, labelR, angle);
+            return (
+              <SvgText
+                key={`ol-${h}`}
+                x={pos.x}
+                y={pos.y + 4}
+                textAnchor="middle"
+                fontSize={isPhone ? 9 : 10}
+                fill={textColor}
+                opacity={0.55}
+              >
+                {h}h
+              </SvgText>
+            );
+          })}
+        </Svg>
       </View>
     </ChartCard>
   );

--- a/components/charts/RenewableBarChart.tsx
+++ b/components/charts/RenewableBarChart.tsx
@@ -320,34 +320,6 @@ function RenewableBarChartComponent({
 
         {/* Bars (SVG) - Using pre-calculated bar data for performance */}
         <Svg width={chartWidth} height={chartHeight}>
-          {/* Renewable Zone Bands - subtle background zones */}
-          {(() => {
-            const chartAreaHeight = chartHeight - padding - bottomPadding;
-            const chartAreaWidth = chartWidth - leftPadding - rightPadding;
-            const zones = [
-              { min: 0, max: 50, color: '#F44336' }, // red: low renewable
-              { min: 50, max: 80, color: '#FFC107' }, // yellow: moderate
-              { min: 80, max: 100, color: '#4CAF50' }, // green: high renewable
-            ];
-            return zones.map((zone, i) => {
-              const yBottom =
-                chartHeight - bottomPadding - ((zone.min - min) / range) * chartAreaHeight;
-              const yTop =
-                chartHeight - bottomPadding - ((zone.max - min) / range) * chartAreaHeight;
-              return (
-                <Rect
-                  key={`zone-${i}`}
-                  x={leftPadding}
-                  y={yTop}
-                  width={chartAreaWidth}
-                  height={yBottom - yTop}
-                  fill={zone.color}
-                  opacity={0.06}
-                />
-              );
-            });
-          })()}
-
           {barData.map(bar => {
             // Render gray fading bar for missing data
             if (bar.value === null) {


### PR DESCRIPTION
## Summary

- **ClockChart (Uhransicht):** Die Stundenmarkierungen (0h, 3h, ...) wurden als `position: absolute` React Native `<Text>`-Elemente außerhalb des SVG gerendert. Da die Koordinaten relativ zum äußeren `<View>` berechnet wurden, nicht zum SVG-Canvas, lagen die Labels weit außerhalb des Rades. Fix: Labels jetzt als SVG `<Text>`-Elemente direkt im SVG. Der SVG-Canvas wurde um 20px Rand erweitert, damit Labels an 0h/12h nicht abgeschnitten werden.

- **RenewableBarChart (Ökostrom-Diagramm):** Die roten/gelben/grünen Hintergrund-Zonen (0–50%, 50–80%, 80–100%) wurden entfernt. Die Information wird bereits über die Balkenfarben kommuniziert – doppelt ist unnötig.

## Test plan
- [ ] Uhransicht öffnen: Labels (0h, 3h, 6h, ...) liegen korrekt außen am Rad, gleichmäßig verteilt
- [ ] Ökostrom-Diagramm: Keine horizontalen Hintergrundstreifen mehr sichtbar
- [ ] Balkenfarben im Ökostrom-Diagramm weiterhin korrekt (grün/gelb/rot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)