### PR TITLE
fix: Metrik immer unter Grafik, Balkendiagramm/Uhrenansicht im Header, keine Korrelations-Details

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -350,6 +350,52 @@ function AppContent() {
                     }
                   : undefined
               }
+              viewToggle={
+                <View style={{ flexDirection: 'row', gap: 6 }}>
+                  <TouchableOpacity
+                    onPress={() => setPriceClockView(false)}
+                    style={{
+                      paddingHorizontal: 10,
+                      paddingVertical: 4,
+                      borderRadius: 8,
+                      backgroundColor: !priceClockView ? colors.primary : colors.gridLine,
+                    }}
+                    accessibilityLabel={t.viewBar}
+                    accessibilityRole="button"
+                  >
+                    <Text
+                      style={{
+                        color: !priceClockView ? '#fff' : colors.text,
+                        fontSize: 12,
+                        fontWeight: '600',
+                      }}
+                    >
+                      📊 {t.viewBar}
+                    </Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    onPress={() => setPriceClockView(true)}
+                    style={{
+                      paddingHorizontal: 10,
+                      paddingVertical: 4,
+                      borderRadius: 8,
+                      backgroundColor: priceClockView ? colors.primary : colors.gridLine,
+                    }}
+                    accessibilityLabel={t.viewClock}
+                    accessibilityRole="button"
+                  >
+                    <Text
+                      style={{
+                        color: priceClockView ? '#fff' : colors.text,
+                        fontSize: 12,
+                        fontWeight: '600',
+                      }}
+                    >
+                      🕐 {t.viewClock}
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+              }
               legend={
                 <View style={{ gap: 8 }}>
                   <Text style={[{ color: colors.text, fontSize: 13, fontWeight: '600' }]}>
@@ -383,52 +429,6 @@ function AppContent() {
                         {t.gridFeesLabel} ({GRID_FEES_AND_TAXES} ¢/kWh)
                       </Text>
                     </View>
-                  </View>
-
-                  {/* View Toggle */}
-                  <View style={{ flexDirection: 'row', gap: 6, marginTop: 4 }}>
-                    <TouchableOpacity
-                      onPress={() => setPriceClockView(false)}
-                      style={{
-                        paddingHorizontal: 10,
-                        paddingVertical: 4,
-                        borderRadius: 8,
-                        backgroundColor: !priceClockView ? colors.primary : colors.gridLine,
-                      }}
-                      accessibilityLabel={t.viewBar}
-                      accessibilityRole="button"
-                    >
-                      <Text
-                        style={{
-                          color: !priceClockView ? '#fff' : colors.text,
-                          fontSize: 12,
-                          fontWeight: '600',
-                        }}
-                      >
-                        📊 {t.viewBar}
-                      </Text>
-                    </TouchableOpacity>
-                    <TouchableOpacity
-                      onPress={() => setPriceClockView(true)}
-                      style={{
-                        paddingHorizontal: 10,
-                        paddingVertical: 4,
-                        borderRadius: 8,
-                        backgroundColor: priceClockView ? colors.primary : colors.gridLine,
-                      }}
-                      accessibilityLabel={t.viewClock}
-                      accessibilityRole="button"
-                    >
-                      <Text
-                        style={{
-                          color: priceClockView ? '#fff' : colors.text,
-                          fontSize: 12,
-                          fontWeight: '600',
-                        }}
-                      >
-                        🕐 {t.viewClock}
-                      </Text>
-                    </TouchableOpacity>
                   </View>
                 </View>
               }
@@ -470,72 +470,22 @@ function AppContent() {
               )}
             </ChartDetailView>
 
-            <ChartDetailView
+            <CorrelationScatterChart
               title={t.correlationTitle}
+              subtitle={`${t.timeRange}: ${filteredEnergyData.length > 0 ? formatDate(filteredEnergyData[0].timestamp) : t.loadingData} - ${filteredEnergyData.length > 0 ? formatDate(filteredEnergyData[filteredEnergyData.length - 1].timestamp) : t.loadingData}`}
+              data={filteredEnergyData}
+              backgroundColor={colors.surface}
+              textColor={colors.text}
+              gridColor={colors.gridLine}
               colors={colors}
-              chartType="correlation"
-              gridFees={gridFees}
-              metrics={undefined}
-              legend={
-                <View style={{ gap: 8 }}>
-                  <Text style={[{ color: colors.text, fontSize: 13, fontWeight: '600' }]}>
-                    {t.legend}
-                  </Text>
-                  <View style={{ flexDirection: 'row', gap: 12, flexWrap: 'wrap' }}>
-                    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-                      <View
-                        style={{
-                          width: 12,
-                          height: 12,
-                          borderRadius: 6,
-                          backgroundColor: '#2196F3',
-                        }}
-                      />
-                      <Text style={{ color: colors.text, fontSize: 12 }}>{t.night}</Text>
-                    </View>
-                    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-                      <View
-                        style={{
-                          width: 12,
-                          height: 12,
-                          borderRadius: 6,
-                          backgroundColor: '#FF9800',
-                        }}
-                      />
-                      <Text style={{ color: colors.text, fontSize: 12 }}>{t.morningEvening}</Text>
-                    </View>
-                    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-                      <View
-                        style={{
-                          width: 12,
-                          height: 12,
-                          borderRadius: 6,
-                          backgroundColor: '#FFEB3B',
-                        }}
-                      />
-                      <Text style={{ color: colors.text, fontSize: 12 }}>{t.day}</Text>
-                    </View>
-                  </View>
-                </View>
-              }
-            >
-              <CorrelationScatterChart
-                title={t.correlationTitle}
-                subtitle={`${t.timeRange}: ${filteredEnergyData.length > 0 ? formatDate(filteredEnergyData[0].timestamp) : t.loadingData} - ${filteredEnergyData.length > 0 ? formatDate(filteredEnergyData[filteredEnergyData.length - 1].timestamp) : t.loadingData}`}
-                data={filteredEnergyData}
-                backgroundColor={colors.surface}
-                textColor={colors.text}
-                gridColor={colors.gridLine}
-                colors={colors}
-                labels={{
-                  yAxisPrice: t.pricePerKwh,
-                  xAxisRenewables: t.renewablePercent,
-                  night: t.night,
-                  morningEvening: t.morningEvening,
-                  day: t.day,
-                }}
-              />
-            </ChartDetailView>
+              labels={{
+                yAxisPrice: t.pricePerKwh,
+                xAxisRenewables: t.renewablePercent,
+                night: t.night,
+                morningEvening: t.morningEvening,
+                day: t.day,
+              }}
+            />
           </>
         ) : null}
         {filteredEnergyData.length === 0 && (

--- a/components/ChartDetailView.tsx
+++ b/components/ChartDetailView.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, TouchableOpacity, Modal, ScrollView, StyleSheet } from 'react-native';
+import { View, Text, Modal, ScrollView, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import type { ThemeColors } from '../utils/theme';
 import { GRID_FEES_AND_TAXES } from '../utils/metrics';
@@ -39,7 +39,7 @@ interface ChartDetailViewProps {
   colors: ThemeColors;
   metrics?: MetricsData;
   chartType: 'renewable' | 'price' | 'correlation';
-  onToggleView?: () => void;
+  viewToggle?: React.ReactNode;
   legend?: React.ReactNode;
   gridFees?: number;
 }
@@ -50,12 +50,11 @@ export function ChartDetailView({
   colors,
   metrics,
   chartType,
-  onToggleView: _onToggleView,
+  viewToggle,
   legend,
   gridFees: _gridFees = GRID_FEES_AND_TAXES,
 }: ChartDetailViewProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const [showMetrics, setShowMetrics] = useState(false);
 
   const renderMetricsView = () => {
     if (!metrics) return null;
@@ -224,69 +223,16 @@ export function ChartDetailView({
 
   const renderContent = () => (
     <View style={{ flex: 1 }}>
-      {/* Toggle buttons - only show if metrics are available */}
-      {metrics && (
-        <View style={styles.toggleContainer}>
-          <TouchableOpacity
-            style={[
-              styles.toggleButton,
-              !showMetrics && styles.toggleButtonActive,
-              {
-                backgroundColor: !showMetrics ? colors.primary : colors.gridLine,
-                borderColor: colors.gridLine,
-              },
-            ]}
-            onPress={() => setShowMetrics(false)}
-          >
-            <Text
-              style={{
-                color: !showMetrics ? '#fff' : colors.text,
-                fontSize: 12,
-                fontWeight: '600',
-              }}
-            >
-              Grafik
-            </Text>
-          </TouchableOpacity>
+      {/* Chart always shown */}
+      <View style={styles.chartContainer}>{children}</View>
 
-          <TouchableOpacity
-            style={[
-              styles.toggleButton,
-              showMetrics && styles.toggleButtonActive,
-              {
-                backgroundColor: showMetrics ? colors.primary : colors.gridLine,
-                borderColor: colors.gridLine,
-              },
-            ]}
-            onPress={() => setShowMetrics(true)}
-          >
-            <Text
-              style={{
-                color: showMetrics ? '#fff' : colors.text,
-                fontSize: 12,
-                fontWeight: '600',
-              }}
-            >
-              Metrik
-            </Text>
-          </TouchableOpacity>
-        </View>
+      {/* Legend - shown below chart */}
+      {legend && (
+        <View style={[styles.legendContainer, { backgroundColor: colors.surface }]}>{legend}</View>
       )}
 
-      {/* Content */}
-      {showMetrics && metrics ? (
-        renderMetricsView()
-      ) : (
-        <>
-          <View style={styles.chartContainer}>{children}</View>
-          {/* Legend - show only when displaying chart (not metrics) */}
-          {legend && (
-            <View style={[styles.legendContainer, { backgroundColor: colors.surface }]}>
-              {legend}
-            </View>
-          )}
-        </>
-      )}
+      {/* Metrics - always shown below chart/legend when available */}
+      {metrics && renderMetricsView()}
     </View>
   );
 
@@ -321,6 +267,7 @@ export function ChartDetailView({
             ]}
           >
             <Text style={[styles.modalTitle, { color: colors.text }]}>{title}</Text>
+            {viewToggle && <View style={{ marginTop: 8 }}>{viewToggle}</View>}
           </View>
 
           {/* Content */}
@@ -380,28 +327,6 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.08,
     shadowRadius: 8,
     elevation: 4,
-  },
-  toggleContainer: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    padding: 16,
-    gap: 8,
-  },
-  toggleButton: {
-    paddingHorizontal: 24,
-    paddingVertical: 10,
-    borderRadius: 12,
-    borderWidth: 0,
-    minWidth: 100,
-    alignItems: 'center',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.08,
-    shadowRadius: 8,
-    elevation: 2,
-  },
-  toggleButtonActive: {
-    // Active style handled via backgroundColor prop
   },
   metricsContainer: {
     margin: 16,


### PR DESCRIPTION
## Änderungen

- **Metrik immer sichtbar:** In der Details-Ansicht von *Börsenstrompreis* und *Anteil erneuerbare Energien* wird die Metrik jetzt immer unterhalb der Grafik angezeigt. Der bisherige Grafik/Metrik-Toggle-Button entfällt.

- **Balkendiagramm/Uhrenansicht im Header:** Die Auswahl zwischen Balkendiagramm und Uhrenansicht ist aus der Legende herausgezogen und erscheint jetzt als `viewToggle`-Prop im Modal-Header (unterhalb des Titels). Die Legende zeigt nur noch die Farberklärungen.

- **Keine Details-Seite für Korrelationsgrafik:** Der `ChartDetailView`-Wrapper um die `CorrelationScatterChart` wurde entfernt. Es gibt keinen Details-Button mehr für diese Grafik.

## Betroffene Dateien
- `components/ChartDetailView.tsx` – Toggle-State/Buttons entfernt, neuer `viewToggle`-Prop, Metrik immer gerendert
- `App.tsx` – View-Toggle aus Legende in `viewToggle`-Prop verschoben, Correlation ohne ChartDetailView

## Test Plan
- [ ] Details-Modal Börsenstrompreis öffnen → Grafik oben, darunter Legende, darunter Metrik
- [ ] Details-Modal Erneuerbare öffnen → Grafik oben, darunter Metrik
- [ ] Im Preischart-Modal: Balkendiagramm/Uhrenansicht-Buttons im Header sichtbar und funktionsfähig
- [ ] Korrelationsgrafik: kein Details-Button mehr sichtbar
- [ ] Legende enthält keinen View-Toggle mehr

🤖 Generated with [Claude Code](https://claude.com/claude-code)