### PR TITLE
fix: Price display mode only affects home screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -434,6 +434,39 @@ function AppContent() {
                   </View>
                 </View>
               }
+              detailLegend={
+                <View style={{ gap: 8 }}>
+                  <Text style={[{ color: colors.text, fontSize: 13, fontWeight: '600' }]}>
+                    {t.legend}
+                  </Text>
+                  <View style={{ gap: 6 }}>
+                    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+                      <View
+                        style={{
+                          width: 16,
+                          height: 16,
+                          backgroundColor: '#4CAF50',
+                          borderRadius: 2,
+                        }}
+                      />
+                      <Text style={{ color: colors.text, fontSize: 12 }}>{t.marketPriceLabel}</Text>
+                    </View>
+                    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+                      <View
+                        style={{
+                          width: 16,
+                          height: 16,
+                          backgroundColor: '#757575',
+                          borderRadius: 2,
+                        }}
+                      />
+                      <Text style={{ color: colors.text, fontSize: 12 }}>
+                        {t.gridFeesLabel} ({gridFees} ¢/kWh)
+                      </Text>
+                    </View>
+                  </View>
+                </View>
+              }
               detailChildren={
                 priceClockView ? (
                   <ClockChart

--- a/components/ChartDetailView.tsx
+++ b/components/ChartDetailView.tsx
@@ -44,6 +44,8 @@ interface ChartDetailViewProps {
   chartType: 'renewable' | 'price' | 'correlation';
   viewToggle?: React.ReactNode;
   legend?: React.ReactNode;
+  /** Optional override for the legend rendered inside the detail modal. */
+  detailLegend?: React.ReactNode;
   gridFees?: number;
 }
 
@@ -56,6 +58,7 @@ export function ChartDetailView({
   chartType,
   viewToggle,
   legend,
+  detailLegend,
   gridFees: _gridFees = GRID_FEES_AND_TAXES,
 }: ChartDetailViewProps) {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -179,9 +182,11 @@ export function ChartDetailView({
       {/* Chart always shown – use detailChildren override when available */}
       <View style={styles.chartContainer}>{detailChildren ?? children}</View>
 
-      {/* Legend - shown below chart */}
-      {legend && (
-        <View style={[styles.legendContainer, { backgroundColor: colors.surface }]}>{legend}</View>
+      {/* Legend - shown below chart, use detailLegend override when available */}
+      {(detailLegend ?? legend) && (
+        <View style={[styles.legendContainer, { backgroundColor: colors.surface }]}>
+          {detailLegend ?? legend}
+        </View>
       )}
 
       {/* Metrics - always shown below chart/legend when available */}


### PR DESCRIPTION
## Summary
- **Startseite**: Respektiert die Einstellung unter "Personalisieren" (Börsenstrompreis vs. Endkundenpreis)
- **Detail-Seite**: Zeigt immer den Endkundenpreis (gestapelte Balken + Metriken), unabhängig von der Einstellung

## Changes
- `ChartDetailView`: Neue `detailChildren` Prop für separates Rendering im Detail-Modal
- `App.tsx`: Detail-Modal bekommt `forceStacked` PriceBarChart
- Detail-Metriken zeigen immer Endkundenpreis (kein `priceDisplayMode` mehr in ChartDetailView)

## Test plan
- [ ] Personalisieren → Börsenstrompreis: Startseite zeigt nur grüne Balken
- [ ] Personalisieren → Endkundenpreis: Startseite zeigt gestapelte Balken (grün + grau)
- [ ] Detail-Ansicht (tap "Details"): Immer gestapelte Balken + Endkundenpreis-Metriken
- [ ] Clock-View im Detail funktioniert weiterhin

🤖 Generated with [Claude Code](https://claude.com/claude-code)