### PR TITLE
Fix: babel.config.js causing Hermes build failure

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,20 +1,6 @@
 module.exports = function(api) {
   api.cache(true);
-
-  // For Jest testing environment - use babel-preset-expo which properly handles Flow types
-  if (process.env.NODE_ENV === 'test') {
-    return {
-      presets: ['babel-preset-expo'],
-    };
-  }
-
-  // For Expo runtime
   return {
-    presets: [
-      ['@babel/preset-env', { targets: { node: 'current' } }],
-      '@babel/preset-flow',
-      '@babel/preset-typescript',
-      ['@babel/preset-react', { runtime: 'automatic' }],
-    ],
+    presets: ['babel-preset-expo'],
   };
 };


### PR DESCRIPTION
## Summary
- **Root cause of Hermes build failure** (both EAS and local): `babel.config.js` used custom presets (`@babel/preset-env` with `targets: { node: 'current' }`) instead of `babel-preset-expo`
- This skipped transpilation of private class fields (`#x`, `#y`) since Node supports them natively — but **Hermes does not**
- The failing code was `DOMRectReadOnly` from `@react-native/webapis` (uses `this.#x`, `this.#y`, etc.)
- **Fix:** Use the standard `babel-preset-expo` for all environments, which correctly transpiles everything for Hermes

## How it was found
1. Local build via `expo prebuild + gradlew bundleRelease` reproduced the exact same error as EAS
2. Inspected the generated bundle at line 23954 → found `DOMRectReadOnly` with private class fields
3. Traced to babel.config.js not transpiling these for Hermes

## Test plan
- [x] Local `gradlew bundleRelease` succeeds (AAB generated, 46 MB)
- [ ] CI checks pass
- [ ] EAS build succeeds with correct version 1.4.0 (11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)