### PR TITLE
fix: apply Copilot suggestions from PR #207 review

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -285,7 +285,7 @@ cd android && ./gradlew bundleRelease --no-daemon
 ```bash
 eas build --platform android --profile production
 ```
-> Note: Migration to local/GitHub Actions builds planned (Issue #202)
+> Note: Migration to local builds completed (Issue #202). EAS cloud build is now legacy and no longer used.
 
 ## Questions?
 Refer to documentation in root directory or check GitHub issues:

--- a/components/ChartDetailView.tsx
+++ b/components/ChartDetailView.tsx
@@ -272,7 +272,7 @@ export function ChartDetailView({
                 onPress={() => setIsExpanded(false)}
                 style={{ flex: 1 }}
               >
-                Schließen
+                {t.close}
               </Button>
             </View>
           </View>

--- a/utils/chartShare.ts
+++ b/utils/chartShare.ts
@@ -55,20 +55,28 @@ async function shareChartWeb(captureRef: React.RefObject<unknown>, title: string
   }
 
   const dataUrl = await toPng(node, { quality: 0.95 });
-  const filename = `${title.replace(/\s+/g, '_')}.png`;
+  // Sanitize filename: remove invalid characters, replace spaces with underscores
+  const filename = `${title.replace(/[^\w\s-]/g, '').replace(/\s+/g, '_')}.png`;
 
-  if (typeof navigator !== 'undefined' && navigator.share) {
-    const blob = await (await fetch(dataUrl)).blob();
-    const file = new File([blob], filename, { type: 'image/png' });
-    await navigator.share({
-      title,
-      files: [file],
-    });
-  } else {
-    // Fallback: trigger download
+  const triggerDownload = () => {
     const a = document.createElement('a');
     a.href = dataUrl;
     a.download = filename;
     a.click();
+  };
+
+  if (typeof navigator !== 'undefined' && navigator.share) {
+    const blob = await (await fetch(dataUrl)).blob();
+    const file = new File([blob], filename, { type: 'image/png' });
+    if (navigator.canShare && navigator.canShare({ files: [file] })) {
+      try {
+        await navigator.share({ title, files: [file] });
+        return;
+      } catch {
+        // Share cancelled or failed – fall through to download
+      }
+    }
   }
+
+  triggerDownload();
 }

--- a/utils/translations.ts
+++ b/utils/translations.ts
@@ -117,6 +117,8 @@ export const translations = {
     shareChartSharing: 'Capturing...',
     shareChartError: 'Could not share chart',
     shareChartDownload: 'Download Chart',
+    // Common actions
+    close: 'Close',
   },
   de: {
     settings: 'Einstellungen',
@@ -235,5 +237,7 @@ export const translations = {
     shareChartSharing: 'Wird erstellt...',
     shareChartError: 'Diagramm konnte nicht geteilt werden',
     shareChartDownload: 'Diagramm herunterladen',
+    // Common actions
+    close: 'Schließen',
   },
 } as const;


### PR DESCRIPTION
Behebt die Copilot-Suggestions aus dem Review von PR #207 (testing→staging).

## Änderungen

- **CLAUDE.md**: EAS-Hinweis aktualisiert – Migration abgeschlossen, nicht mehr geplant
- **translations.ts**: `close`-Key (DE/EN) ergänzt für i18n-Konsistenz
- **ChartDetailView**: `t.close` statt hardcodiertem `'Schließen'`
- **chartShare.ts**: Dateiname-Sanitisierung (ungültige Zeichen entfernen)
- **chartShare.ts**: `navigator.canShare`-Check vor File-Share; Fallback auf Download

🤖 Generated with [Claude Code](https://claude.ai/claude-code)