### PR TITLE
chore: bump version to 1.4.1 (versionCode 12)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -30,7 +30,7 @@ import { useSettingsContext } from './context/SettingsContext';
 import { checkPriceAlert } from './utils/priceAlertUtils';
 import { usePriceAlertNotification } from './hooks/usePriceAlertNotification';
 
-const APP_VERSION = '1.4.0';
+const APP_VERSION = '1.4.1';
 
 function AppContent() {
   // UI State only (modals)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2026-02-27
+
+### Added
+- **Diagramm teilen** – Charts können als PNG-Screenshot geteilt oder heruntergeladen werden (Android: System-Share-Sheet, Web: Download oder Browser-Share) (#163)
+
+### Changed
+- Android-Build vollständig lokal via Gradle (kein EAS Cloud Build mehr) (#202)
+
+---
+
 ## [1.4.0] - 2026-02-22
 
 ### Added

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Energy Prices Germany",
     "slug": "Energy_Price_Germany",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -36,7 +36,7 @@
         "backgroundColor": "#ffffff"
       },
       "package": "com.sven4321.energypricegermany",
-      "versionCode": 11,
+      "versionCode": 12,
       "permissions": [
         "INTERNET",
         "ACCESS_NETWORK_STATE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "energypricegermany",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Energy price visualization for Germany with market data and renewable energy share",
   "main": "index.ts",
   "homepage": "https://s540d.github.io/Energy_Price_Germany/",


### PR DESCRIPTION
## Version Bump: 1.4.0 → 1.4.1

| Datei | Alt | Neu |
|-------|-----|-----|
| `app.json` version | 1.4.0 | 1.4.1 |
| `app.json` versionCode | 11 | 12 |
| `package.json` | 1.4.0 | 1.4.1 |
| `App.tsx` APP_VERSION | 1.4.0 | 1.4.1 |

### CHANGELOG 1.4.1
- feat: Diagramm teilen als PNG (#163)
- chore: lokaler Android-Build, kein EAS mehr (#202)

## Test plan
- [ ] CI-Check `platform-checks` validiert Versions-Konsistenz ✓

🤖 Generated with [Claude Code](https://claude.ai/claude-code)