### PR TITLE
fix: UX improvements for customize panel and cost calculator (#210, #211)

### DIFF
--- a/components/CostCalculator.tsx
+++ b/components/CostCalculator.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo } from 'react';
-import { View, Text, StyleSheet, useColorScheme } from 'react-native';
-import { useLanguageContext } from '../context/LanguageContext';
+import { View, StyleSheet, useColorScheme } from 'react-native';
 import { getThemeColors } from '../utils/theme';
 import { useSettingsContext } from '../context/SettingsContext';
 import { ApplianceTimeline } from './ApplianceTimeline';
@@ -77,18 +76,12 @@ interface CostCalculatorProps {
  * Shows a timeline of the best hours to run each household appliance.
  */
 export function CostCalculator({ priceData = [], gridFees = 0 }: CostCalculatorProps) {
-  const { t } = useLanguageContext();
   const { theme } = useSettingsContext();
   const systemTheme = useColorScheme();
   const colors = useMemo(() => getThemeColors(theme, systemTheme || 'light'), [theme, systemTheme]);
 
   return (
     <View style={[styles.container, { backgroundColor: colors.surface }]}>
-      <Text style={[styles.title, { color: colors.text }]}>{t.costCalculatorTitle}</Text>
-      <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
-        {t.costCalculatorSubtitle}
-      </Text>
-
       {priceData.length > 0 && (
         <ApplianceTimeline appliances={APPLIANCES} priceData={priceData} gridFees={gridFees} />
       )}
@@ -102,13 +95,5 @@ const styles = StyleSheet.create({
     borderRadius: 16,
     marginVertical: 10,
     gap: 16,
-  },
-  title: {
-    fontSize: 18,
-    fontWeight: '700',
-  },
-  subtitle: {
-    fontSize: 13,
-    lineHeight: 18,
   },
 });

--- a/components/customize/CustomizeModal.tsx
+++ b/components/customize/CustomizeModal.tsx
@@ -48,13 +48,15 @@ export function CustomizeModal({ visible, onClose }: CustomizeModalProps) {
 
           <View style={[styles.separator, { backgroundColor: colors.gridLine }]} />
 
-          {/* Postal Code Section */}
-          <PostalCodeSection />
-
-          <View style={[styles.separator, { backgroundColor: colors.gridLine }]} />
-
-          {/* Grid Fees Section */}
-          <GridFeesSection />
+          {/* Postal Code + Grid Fees in one row */}
+          <View style={styles.inlineRow}>
+            <View style={styles.inlineItem}>
+              <PostalCodeSection />
+            </View>
+            <View style={styles.inlineItem}>
+              <GridFeesSection />
+            </View>
+          </View>
 
           <View style={[styles.separator, { backgroundColor: colors.gridLine }]} />
 
@@ -121,5 +123,12 @@ const styles = StyleSheet.create({
   separator: {
     height: 1,
     marginVertical: 4,
+  },
+  inlineRow: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  inlineItem: {
+    flex: 1,
   },
 });

--- a/components/customize/GridFeesSection.tsx
+++ b/components/customize/GridFeesSection.tsx
@@ -32,41 +32,34 @@ export function GridFeesSection() {
   return (
     <View style={styles.menuSection}>
       <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>{t.gridFees}</Text>
-      <View>
-        <Text style={[styles.hintText, { color: colors.textSecondary }]}>{t.gridFeesHint}</Text>
-        <TextInput
-          style={[
-            styles.input,
-            {
-              backgroundColor: colors.surface,
-              color: colors.text,
-              borderColor: colors.gridLine,
-            },
-          ]}
-          placeholder={t.gridFeesValue}
-          placeholderTextColor={colors.textSecondary}
-          value={gridFees.toString()}
-          onChangeText={handleGridFeesChange}
-          keyboardType="numeric"
-        />
-      </View>
+      <TextInput
+        style={[
+          styles.input,
+          {
+            backgroundColor: colors.surface,
+            color: colors.text,
+            borderColor: colors.gridLine,
+          },
+        ]}
+        placeholder={t.gridFeesValue}
+        placeholderTextColor={colors.textSecondary}
+        value={gridFees.toString()}
+        onChangeText={handleGridFeesChange}
+        keyboardType="numeric"
+      />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   menuSection: {
-    gap: 12,
+    gap: 8,
   },
   sectionTitle: {
     fontSize: 11,
     fontWeight: '700',
     textTransform: 'uppercase',
     letterSpacing: 0.5,
-  },
-  hintText: {
-    fontSize: 12,
-    marginBottom: 8,
   },
   input: {
     borderWidth: 1,

--- a/components/customize/PostalCodeSection.tsx
+++ b/components/customize/PostalCodeSection.tsx
@@ -18,44 +18,37 @@ export function PostalCodeSection() {
   return (
     <View style={styles.menuSection}>
       <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>{t.region}</Text>
-      <View>
-        <Text style={[styles.hintText, { color: colors.textSecondary }]}>{t.postalCodeHint}</Text>
-        <TextInput
-          style={[
-            styles.input,
-            {
-              backgroundColor: colors.surface,
-              color: colors.text,
-              borderColor: colors.gridLine,
-            },
-          ]}
-          placeholder={t.postalCode}
-          placeholderTextColor={colors.textSecondary}
-          value={postalCode}
-          onChangeText={text => {
-            setPostalCode(sanitizePostalCodeInput(text));
-          }}
-          keyboardType="numeric"
-          maxLength={5}
-        />
-      </View>
+      <TextInput
+        style={[
+          styles.input,
+          {
+            backgroundColor: colors.surface,
+            color: colors.text,
+            borderColor: colors.gridLine,
+          },
+        ]}
+        placeholder={t.postalCode}
+        placeholderTextColor={colors.textSecondary}
+        value={postalCode}
+        onChangeText={text => {
+          setPostalCode(sanitizePostalCodeInput(text));
+        }}
+        keyboardType="numeric"
+        maxLength={5}
+      />
     </View>
   );
 }
 
 const styles = StyleSheet.create({
   menuSection: {
-    gap: 12,
+    gap: 8,
   },
   sectionTitle: {
     fontSize: 11,
     fontWeight: '700',
     textTransform: 'uppercase',
     letterSpacing: 0.5,
-  },
-  hintText: {
-    fontSize: 12,
-    marginBottom: 8,
   },
   input: {
     borderWidth: 1,


### PR DESCRIPTION
## Summary
- **Fix #210:** Postleitzahl und Netzentgelt im Personalisieren-Panel auf eine Zeile zusammengeführt (nebeneinander statt untereinander)
- **Fix #211:** Redundante Titel/Untertitel im CostCalculator entfernt – der Header wird bereits von `CostCalculatorView` gezeigt

## Changes
- `components/customize/CustomizeModal.tsx` – PLZ + Netzentgelt in `inlineRow` nebeneinander
- `components/customize/PostalCodeSection.tsx` – Hint-Text entfernt, Gap reduziert
- `components/customize/GridFeesSection.tsx` – Hint-Text entfernt, Gap reduziert
- `components/CostCalculator.tsx` – `title` + `subtitle` entfernt, unused imports bereinigt

## Test plan
- [ ] Personalisieren-Panel öffnen → PLZ und Netzentgelt erscheinen nebeneinander in einer Zeile
- [ ] "Was kostet das"-Seite öffnen → kein doppelter Titel mehr
- [ ] Beide Sprachen (DE/EN) prüfen