### PR TITLE
fix: apply Copilot suggestions from PR #213 review

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -591,11 +591,6 @@ function AppContent() {
       <CostCalculatorView
         visible={calculatorVisible}
         onClose={() => setCalculatorVisible(false)}
-        currentPrice={
-          metrics?.today?.marketPrice.current
-            ? metrics.today.marketPrice.current + gridFees
-            : gridFees
-        }
         priceData={filteredEnergyData
           .filter(item => item.marketPrice !== null)
           .map(item => ({

--- a/components/CostCalculator.tsx
+++ b/components/CostCalculator.tsx
@@ -67,7 +67,6 @@ export const APPLIANCES: Appliance[] = [
 ];
 
 interface CostCalculatorProps {
-  currentPrice: number; // in ct/kWh (includes grid fees)
   priceData?: Array<{ start_timestamp: number; marketprice: number; renewable_share?: number }>;
   gridFees?: number; // ct/kWh
 }

--- a/components/CostCalculatorView.tsx
+++ b/components/CostCalculatorView.tsx
@@ -10,7 +10,6 @@ import { CostCalculator } from './CostCalculator';
 interface CostCalculatorViewProps {
   visible: boolean;
   onClose: () => void;
-  currentPrice: number;
   priceData?: Array<{ start_timestamp: number; marketprice: number; renewable_share?: number }>;
   gridFees?: number;
 }
@@ -22,7 +21,6 @@ interface CostCalculatorViewProps {
 export function CostCalculatorView({
   visible,
   onClose,
-  currentPrice,
   priceData,
   gridFees,
 }: CostCalculatorViewProps) {
@@ -56,7 +54,7 @@ export function CostCalculatorView({
 
       {/* Content */}
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
-        <CostCalculator currentPrice={currentPrice} priceData={priceData} gridFees={gridFees} />
+        <CostCalculator priceData={priceData} gridFees={gridFees} />
       </ScrollView>
     </SafeAreaView>
   );

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -560,6 +560,6 @@ Success? ──Yes──→ ✅ Complete
 
 ---
 
-**Last Updated**: 2026-02-25
-**Current Version**: 1.4.0
+**Last Updated**: 2026-03-02
+**Current Version**: 1.4.1
 **Maintainer**: S540d

--- a/utils/chartShare.ts
+++ b/utils/chartShare.ts
@@ -6,6 +6,7 @@
  * - Web: html-to-image + navigator.share() or download fallback
  */
 
+import type { RefObject } from 'react';
 import { isWeb, isMobile } from './platform';
 
 /**
@@ -14,10 +15,7 @@ import { isWeb, isMobile } from './platform';
  * @param captureRef - React ref attached to the View wrapping the chart
  * @param title - Chart title used as filename and share text
  */
-export async function shareChart(
-  captureRef: React.RefObject<unknown>,
-  title: string
-): Promise<void> {
+export async function shareChart(captureRef: RefObject<unknown>, title: string): Promise<void> {
   if (isMobile) {
     await shareChartMobile(captureRef, title);
   } else if (isWeb) {
@@ -25,10 +23,7 @@ export async function shareChart(
   }
 }
 
-async function shareChartMobile(
-  captureRef: React.RefObject<unknown>,
-  title: string
-): Promise<void> {
+async function shareChartMobile(captureRef: RefObject<unknown>, title: string): Promise<void> {
   const { captureRef: captureViewRef } = await import('react-native-view-shot');
   const { Share } = await import('react-native');
 
@@ -45,7 +40,7 @@ async function shareChartMobile(
   });
 }
 
-async function shareChartWeb(captureRef: React.RefObject<unknown>, title: string): Promise<void> {
+async function shareChartWeb(captureRef: RefObject<unknown>, title: string): Promise<void> {
   const { toPng } = await import('html-to-image');
 
   // On web, captureRef.current is the underlying DOM node


### PR DESCRIPTION
## Summary
Addresses Copilot review findings on PR #213 (Release 1.4.1):

- **chartShare.ts**: Replace `React.RefObject` with properly imported `RefObject` from 'react' (type import)
- **CostCalculator/CostCalculatorView/App.tsx**: Remove unused `currentPrice` prop through the entire call chain
- **ARCHITECTURE.md**: Update version to 1.4.1 and date to 2026-03-02