### PR TITLE
chore: bump version to 1.4.2 (versionCode 13)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -30,7 +30,7 @@ import { useSettingsContext } from './context/SettingsContext';
 import { checkPriceAlert } from './utils/priceAlertUtils';
 import { usePriceAlertNotification } from './hooks/usePriceAlertNotification';
 
-const APP_VERSION = '1.4.1';
+const APP_VERSION = '1.4.2';
 
 function AppContent() {
   // UI State only (modals)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.2] - 2026-03-02
+
+### Fixed
+- PLZ und Netzentgelte im Personalisieren-Panel nebeneinander (eine Zeile) (#210)
+- Redundante Titel aus der "Was kostet das"-Ansicht entfernt (#211)
+
+---
+
 ## [1.4.1] - 2026-02-27
 
 ### Added

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Energy Prices Germany",
     "slug": "Energy_Price_Germany",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -36,7 +36,7 @@
         "backgroundColor": "#ffffff"
       },
       "package": "com.sven4321.energypricegermany",
-      "versionCode": 12,
+      "versionCode": 13,
       "permissions": [
         "INTERNET",
         "ACCESS_NETWORK_STATE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "energypricegermany",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Energy price visualization for Germany with market data and renewable energy share",
   "main": "index.ts",
   "homepage": "https://s540d.github.io/Energy_Price_Germany/",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -28,6 +28,6 @@
   "theme_color": "#6200EE",
   "background_color": "#ffffff",
   "orientation": "portrait",
-  "version": "1.3.0",
-  "build_date": "2026-01-18"
+  "version": "1.4.2",
+  "build_date": "2026-03-02"
 }

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -3,7 +3,7 @@
 
 // SECURITY FIX: Use dynamic timestamp instead of hardcoded value
 // This ensures cache busting works correctly even after SW updates
-const CACHE_VERSION = '1.3.0';
+const CACHE_VERSION = '1.4.2';
 const CACHE_TIMESTAMP = Date.now(); // Dynamic timestamp
 const CACHE_NAME = `energy-price-germany-v${CACHE_VERSION}-${CACHE_TIMESTAMP}`;
 const urlsToCache = [


### PR DESCRIPTION
## Summary
- Bumps version from 1.4.1 → 1.4.2 (versionCode 12 → 13)
- Updates `package.json`, `app.json`, `App.tsx` (APP_VERSION), `public/manifest.json`, `public/service-worker.js`
- Adds CHANGELOG entry for 1.4.2 (UX fixes #210, #211)

## Changes
- PLZ und Netzentgelte im Personalisieren-Panel nebeneinander (#210)
- Redundante Titel aus der "Was kostet das"-Ansicht entfernt (#211)

🤖 Generated with [Claude Code](https://claude.com/claude-code)