### PR TITLE
fix: SettingsMenu Overlay pointerEvents während Schließ-Animation

### DIFF
--- a/components/settings/SettingsMenu.tsx
+++ b/components/settings/SettingsMenu.tsx
@@ -69,7 +69,7 @@ export function SettingsMenu({
       {/* Animated Overlay */}
       <Animated.View
         style={[styles.overlay, overlayAnimatedStyle]}
-        pointerEvents={visible ? 'auto' : 'none'}
+        pointerEvents={isMounted ? 'auto' : 'none'}
       >
         <TouchableOpacity style={StyleSheet.absoluteFill} activeOpacity={1} onPress={onClose} />
       </Animated.View>


### PR DESCRIPTION
## Problem

Copilot-Suggestion aus PR #236: Der Overlay wechselte `pointerEvents` auf `'none'` sobald `visible=false` gesetzt wird — zu diesem Zeitpunkt läuft die Schließ-Animation aber noch ~250ms weiter. In dieser Zeit konnten Touches durch den Overlay auf darunter liegende UI-Elemente durchdringen.

## Fix

`pointerEvents={isMounted ? 'auto' : 'none'}` — der Overlay blockiert Touches für die gesamte Dauer seiner Existenz im DOM (bis `isMounted=false` am Ende der Austritts-Animation gesetzt wird).

## Betroffene Datei

- `components/settings/SettingsMenu.tsx`