### PR TITLE
fix: Hardcoded 'Hint:' Prefix aus Chart-Komponenten entfernt (#238)

### DIFF
--- a/components/charts/CorrelationScatterChart.tsx
+++ b/components/charts/CorrelationScatterChart.tsx
@@ -253,7 +253,7 @@ function CorrelationScatterChartComponent({
               accessibilityRole="text"
               accessibilityLabel={interactionHint}
             >
-              Hint: {interactionHint}
+              {interactionHint}
             </Text>
           )}
         </View>
@@ -452,7 +452,7 @@ function CorrelationScatterChartComponent({
             marginTop: 8,
           }}
         >
-          Hint: {interactionHint}
+          {interactionHint}
         </Text>
       )}
     </ChartCard>

--- a/components/charts/PriceBarChart.tsx
+++ b/components/charts/PriceBarChart.tsx
@@ -284,7 +284,7 @@ function PriceBarChartComponent({
               accessibilityRole="text"
               accessibilityLabel={interactionHint}
             >
-              Hint: {interactionHint}
+              {interactionHint}
             </Text>
           )}
         </View>
@@ -563,7 +563,7 @@ function PriceBarChartComponent({
             marginTop: 8,
           }}
         >
-          Hint: {interactionHint}
+          {interactionHint}
         </Text>
       )}
     </ChartCard>

--- a/components/charts/RenewableBarChart.tsx
+++ b/components/charts/RenewableBarChart.tsx
@@ -264,7 +264,7 @@ function RenewableBarChartComponent({
               accessibilityRole="text"
               accessibilityLabel={interactionHint}
             >
-              Hint: {interactionHint}
+              {interactionHint}
             </Text>
           )}
         </View>
@@ -642,7 +642,7 @@ function RenewableBarChartComponent({
             marginTop: 8,
           }}
         >
-          Hint: {interactionHint}
+          {interactionHint}
         </Text>
       )}
     </ChartCard>


### PR DESCRIPTION
## Problem

In `PriceBarChart`, `RenewableBarChart` und `CorrelationScatterChart` war das Prefix `Hint:` vor dem `interactionHint`-Text hardcoded. Bei deutscher Spracheinstellung wurde `Hint:` trotzdem auf Englisch angezeigt.

## Fix

`Hint: {interactionHint}` → `{interactionHint}` in allen drei Komponenten. Der Hint-Text selbst ist bereits vollständig beschreibend.

## Betroffene Dateien

- `components/charts/PriceBarChart.tsx` (2 Stellen)
- `components/charts/RenewableBarChart.tsx` (2 Stellen)
- `components/charts/CorrelationScatterChart.tsx` (2 Stellen)

Closes #238