### PR TITLE
fix: Copilot-Suggestions aus PR #242 umsetzen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - **Animierter Theme-Schieberegler** – In den Einstellungen gleitet ein Pill-Indikator beim Wechsel zwischen Hell/Dunkel/System-Theme
 
 ### Changed
-- **Expo SDK 55** – Upgrade von SDK 54 auf SDK 55; `expo-av` durch `expo-audio` ersetzt
+- **Expo SDK 55** – Upgrade von SDK 54 auf SDK 55
 - **Flüssigere Animationen** – Alle UI-Animationen auf `react-native-reanimated` 3.17 umgestellt (vorher: React Native `Animated` API)
 - **Einstellungen-Panel** – Öffnet und schließt sich jetzt mit einer Slide-up/down-Animation statt abrupt zu erscheinen
 - **Chart-Ansichts-Toggle** – Wechsel zwischen Balken- und Uhransicht erfolgt mit sanftem Übergang

--- a/README.md
+++ b/README.md
@@ -52,10 +52,9 @@ To evolve the current look into a cleaner and more modern product, use this incr
    - Migrate chart rendering from SVG-heavy paths to `@shopify/react-native-skia` for smoother animation and better visual polish on mobile.
    - Introduce Skia chart primitives behind feature flags and run both renderers in parallel during rollout.
 
-3. **Platform Upgrade (latest Expo SDK)**
-   - Upgrade Expo SDK and React Native in one controlled step, then validate Android, iOS, and web parity.
-   - Re-run performance baselines (initial render, chart interaction, memory) before and after migration.
-   - After stable rollout, remove legacy chart paths and consolidate theming tokens.
+3. **Platform Status (Expo SDK 55 / RN 0.83 — completed)**
+   - The project is already on Expo SDK 55 and React Native 0.83 in this release.
+   - Continue to validate Android, iOS, and web parity and monitor for any upgrade-related regressions.
 
 This sequence keeps risk low: first improve UI immediately, then modernize rendering and platform stack with measurable checkpoints.
 

--- a/components/settings/AppearanceSection.tsx
+++ b/components/settings/AppearanceSection.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { View, Text, StyleSheet, useColorScheme, Pressable } from 'react-native';
 import type { LayoutChangeEvent } from 'react-native';
 import Animated, { useSharedValue, useAnimatedStyle, withSpring } from 'react-native-reanimated';
@@ -58,6 +58,16 @@ export function AppearanceSection() {
       }
     }
   };
+
+  useEffect(() => {
+    if (!layoutsReady) return;
+    const active = layouts.current[theme];
+    if (active) {
+      pillX.value = withSpring(active.x, { damping: 20, stiffness: 300 });
+      pillWidth.value = withSpring(active.width, { damping: 20, stiffness: 300 });
+      pillHeight.value = withSpring(active.height, { damping: 20, stiffness: 300 });
+    }
+  }, [theme, layoutsReady, pillX, pillWidth, pillHeight]);
 
   const handleThemePress = (themeOption: Theme) => {
     setTheme(themeOption);


### PR DESCRIPTION
## Summary
- `CHANGELOG.md`: Falschen `expo-av → expo-audio`-Hinweis entfernt
- `README.md`: Expo SDK 55 Platform-Upgrade als abgeschlossen markiert
- `AppearanceSection.tsx`: `useEffect` hinzugefügt, der die Pill-Position synchronisiert wenn `theme` nach dem Mount ändert (z.B. nach asynchronem Laden aus AsyncStorage)

Fixes Copilot-Review-Kommentare auf PR #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)