### PR TITLE
fix: Update react-native-reanimated 3.17→3.19.5 (Android build fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "energypricegermany",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "energypricegermany",
-      "version": "1.4.3",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^2.2.0",
@@ -18,7 +18,7 @@
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "react-native": "0.83.2",
-        "react-native-reanimated": "~3.17.5",
+        "react-native-reanimated": "~3.19.5",
         "react-native-safe-area-context": "~5.6.2",
         "react-native-svg": "15.15.3",
         "react-native-view-shot": "^4.0.3",
@@ -13272,9 +13272,9 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.17.5.tgz",
-      "integrity": "sha512-SxBK7wQfJ4UoWoJqQnmIC7ZjuNgVb9rcY5Xc67upXAFKftWg0rnkknTw6vgwnjRcvYThrjzUVti66XoZdDJGtw==",
+      "version": "3.19.5",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.19.5.tgz",
+      "integrity": "sha512-bd4AwIkBAaY4BjrgpSoKjEaRG/tXD756F5nGuiH5IMBSKN8tRdUEA8hWZCyIo/R6/kha/tVSoCqodVUACh7ZWw==",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-native": "0.83.2",
-    "react-native-reanimated": "~3.17.5",
+    "react-native-reanimated": "~3.19.5",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-svg": "15.15.3",
     "react-native-view-shot": "^4.0.3",


### PR DESCRIPTION
## Problem
Android AAB Build schlägt fehl mit:
```
UIManagerModuleListener: Symbol nicht gefunden
Systrace.TRACE_TAG_REACT_JAVA_BRIDGE: Symbol nicht gefunden
```

`react-native-reanimated` 3.17 referenziert Legacy-Bridge-APIs die in React Native 0.83 (New Architecture) entfernt wurden.

## Fix
Update auf `react-native-reanimated` ~3.19.5 – diese Version ist vollständig mit RN 0.83 + New Architecture kompatibel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)