### PR TITLE
Fix #246, #247: Reanimated 4.x upgrade + chart Y-axis clamp

### DIFF
--- a/components/charts/PriceBarChart.tsx
+++ b/components/charts/PriceBarChart.tsx
@@ -98,9 +98,8 @@ function PriceBarChartComponent({
     if (validData.length === 0) return null;
 
     const pricesInCent = validData.map(d => (d.marketPrice ?? 0) * 0.1);
-    const minPrice = Math.min(...pricesInCent, 0);
     const maxPrice = Math.max(...pricesInCent);
-    const min = Math.floor(minPrice / 5) * 5;
+    const min = 0;
     const maxMarketPrice = Math.ceil(maxPrice / 5) * 5;
     const maxTotal = isMarketOnly ? maxMarketPrice : maxMarketPrice + gridFees;
     const range = maxTotal - min;
@@ -136,8 +135,9 @@ function PriceBarChartComponent({
 
       const totalPrice = isMarketOnly ? marketPrice : marketPrice + gridFees;
       const color = getPriceColor(totalPrice);
+      const clampedMarketPrice = Math.max(0, marketPrice);
       const marketBarHeight =
-        ((marketPrice - cMin) / cRange) * (chartHeight - padding - bottomPadding);
+        ((clampedMarketPrice - cMin) / cRange) * (chartHeight - padding - bottomPadding);
       const marketY = chartHeight - bottomPadding - marketBarHeight;
       const gridBarHeight = (gridFees / cRange) * (chartHeight - padding - bottomPadding);
       const gridY = marketY - gridBarHeight;

--- a/components/settings/AppearanceSection.tsx
+++ b/components/settings/AppearanceSection.tsx
@@ -31,19 +31,21 @@ export function AppearanceSection() {
   const pillX = useSharedValue(0);
   const pillWidth = useSharedValue(0);
   const pillHeight = useSharedValue(0);
+  const pillColor = useSharedValue(colors.primary);
 
-  const pillStyle = useAnimatedStyle(
-    () => ({
-      position: 'absolute',
-      left: pillX.value,
-      width: pillWidth.value,
-      height: pillHeight.value,
-      backgroundColor: colors.primary,
-      borderRadius: borderRadius.md,
-      zIndex: 0,
-    }),
-    [colors.primary]
-  );
+  useEffect(() => {
+    pillColor.value = colors.primary;
+  }, [pillColor, colors.primary]);
+
+  const pillStyle = useAnimatedStyle(() => ({
+    position: 'absolute',
+    left: pillX.value,
+    width: pillWidth.value,
+    height: pillHeight.value,
+    backgroundColor: pillColor.value,
+    borderRadius: borderRadius.md,
+    zIndex: 0,
+  }));
 
   const handleLayout = (themeOption: Theme) => (e: LayoutChangeEvent) => {
     const { x, width, height } = e.nativeEvent.layout;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,11 +18,12 @@
         "react": "19.2.0",
         "react-dom": "19.2.0",
         "react-native": "0.83.2",
-        "react-native-reanimated": "~3.19.5",
+        "react-native-reanimated": "4.2.1",
         "react-native-safe-area-context": "~5.6.2",
         "react-native-svg": "15.15.3",
         "react-native-view-shot": "^4.0.3",
-        "react-native-web": "~0.21.0"
+        "react-native-web": "~0.21.0",
+        "react-native-worklets": "0.7.2"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.28.5",
@@ -13272,38 +13273,30 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "3.19.5",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.19.5.tgz",
-      "integrity": "sha512-bd4AwIkBAaY4BjrgpSoKjEaRG/tXD756F5nGuiH5IMBSKN8tRdUEA8hWZCyIo/R6/kha/tVSoCqodVUACh7ZWw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-4.2.1.tgz",
+      "integrity": "sha512-/NcHnZMyOvsD/wYXug/YqSKw90P9edN0kEPL5lP4PFf1aQ4F1V7MKe/E0tvfkXKIajy3Qocp5EiEnlcrK/+BZg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
-        "@babel/plugin-transform-class-properties": "^7.0.0-0",
-        "@babel/plugin-transform-classes": "^7.0.0-0",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
-        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
-        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
-        "@babel/plugin-transform-template-literals": "^7.0.0-0",
-        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
-        "@babel/preset-typescript": "^7.16.7",
-        "convert-source-map": "^2.0.0",
-        "invariant": "^2.2.4",
-        "react-native-is-edge-to-edge": "1.1.7"
+        "react-native-is-edge-to-edge": "1.2.1",
+        "semver": "7.7.3"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0",
         "react": "*",
-        "react-native": "*"
+        "react-native": "*",
+        "react-native-worklets": ">=0.7.0"
       }
     },
-    "node_modules/react-native-reanimated/node_modules/react-native-is-edge-to-edge": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.7.tgz",
-      "integrity": "sha512-EH6i7E8epJGIcu7KpfXYXiV2JFIYITtq+rVS8uEb+92naMRBdxhTuS8Wn2Q7j9sqyO0B+Xbaaf9VdipIAmGW4w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
+    "node_modules/react-native-reanimated/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-native-safe-area-context": {
@@ -13375,6 +13368,77 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
+    },
+    "node_modules/react-native-worklets": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.7.2.tgz",
+      "integrity": "sha512-DuLu1kMV/Uyl9pQHp3hehAlThoLw7Yk2FwRTpzASOmI+cd4845FWn3m2bk9MnjUw8FBRIyhwLqYm2AJaXDXsog==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-arrow-functions": "7.27.1",
+        "@babel/plugin-transform-class-properties": "7.27.1",
+        "@babel/plugin-transform-classes": "7.28.4",
+        "@babel/plugin-transform-nullish-coalescing-operator": "7.27.1",
+        "@babel/plugin-transform-optional-chaining": "7.27.1",
+        "@babel/plugin-transform-shorthand-properties": "7.27.1",
+        "@babel/plugin-transform-template-literals": "7.27.1",
+        "@babel/plugin-transform-unicode-regex": "7.27.1",
+        "@babel/preset-typescript": "7.27.1",
+        "convert-source-map": "2.0.0",
+        "semver": "7.7.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-worklets/node_modules/@babel/plugin-transform-optional-chaining": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz",
+      "integrity": "sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/react-native-worklets/node_modules/@babel/preset-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
+      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/react-native-worklets/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/react-native/node_modules/@react-native/virtualized-lists": {
       "version": "0.83.2",

--- a/package.json
+++ b/package.json
@@ -50,11 +50,12 @@
     "react": "19.2.0",
     "react-dom": "19.2.0",
     "react-native": "0.83.2",
-    "react-native-reanimated": "~3.19.5",
+    "react-native-reanimated": "4.2.1",
     "react-native-safe-area-context": "~5.6.2",
     "react-native-svg": "15.15.3",
     "react-native-view-shot": "^4.0.3",
-    "react-native-web": "~0.21.0"
+    "react-native-web": "~0.21.0",
+    "react-native-worklets": "0.7.2"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.28.5",


### PR DESCRIPTION
## Summary
- **#247**: Upgrade `react-native-reanimated` 3.19.5 → 4.2.1 + add `react-native-worklets` 0.7.2 (fixes Android build blocker with Expo SDK 55)
- **#246**: Clamp PriceBarChart Y-axis minimum to 0 — negative prices render as zero-height bars, tooltip still shows actual values
- Fix `useAnimatedStyle` breaking change in AppearanceSection (dependency array removed in Reanimated v4)

## Test plan
- [ ] Web build passes (`npx expo export --platform web` ✅ verified locally)
- [ ] All chart animations work (PriceBarChart, RenewableBarChart, ChartCard, ChartTooltip, SkeletonLoader)
- [ ] Theme switching animation in AppearanceSection still works
- [ ] Tooltip shows correct negative prices when tapping bars with negative market prices
- [ ] Android prebuild + Gradle build succeeds (blocked until this PR merges)

Closes #246, Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)