### PR TITLE
Fix: Button text unreadable on old Android in detail modal

### DIFF
--- a/components/ChartDetailView.tsx
+++ b/components/ChartDetailView.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from 'react';
-import { Alert, View, Text, Modal, ScrollView, StyleSheet } from 'react-native';
+import { Alert, Platform, View, Text, Modal, ScrollView, StyleSheet } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import type { ThemeColors } from '../utils/theme';
 import { GRID_FEES_AND_TAXES } from '../utils/metrics';
@@ -311,7 +311,7 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: -2 },
     shadowOpacity: 0.08,
     shadowRadius: 8,
-    elevation: 4,
+    elevation: Platform.OS === 'android' ? 0 : 4,
   },
   footerButtons: {
     flexDirection: 'row',

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -60,7 +60,7 @@ export function Button({
     },
     variant === 'outlined' && {
       borderColor: disabled ? colors.disabled : colors.primary,
-      backgroundColor: 'transparent',
+      backgroundColor: Platform.OS === 'android' ? colors.surface : 'transparent',
     },
     variant === 'ghost' && {
       backgroundColor: 'transparent',
@@ -128,7 +128,7 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.15,
     shadowRadius: 8,
-    elevation: 3,
+    elevation: Platform.OS === 'android' ? 0 : 3,
   },
   variant_outlined: {
     borderWidth: 1.5,


### PR DESCRIPTION
## Summary
- Auf altem Android erzeugt `elevation` + `borderRadius` weiße Hintergrund-Artefakte, die den Button-Text überdecken
- **outlined** Buttons: `backgroundColor: transparent` → `colors.surface` auf Android
- **filled** Buttons: `elevation: 3` → `0` auf Android (Schatten nicht nötig, verhindert weißen Rand)
- Detail-Modal Footer: `elevation: 4` → `0` auf Android (verhindert Artefakte bei Kinder-Elementen)
- Gleicher Ansatz wie der vorherige Fix für den "Details"-Button (#254)

## Test plan
- [ ] Altes Android-Gerät: Detail-View öffnen → "Teilen" und "Schließen" Buttons lesbar
- [ ] iOS/Web: Buttons sehen unverändert aus (Elevation bleibt dort erhalten)
- [ ] Dark Mode + Light Mode prüfen

🤖 Generated with [Claude Code](https://claude.com/claude-code)