### PR TITLE
fix: Copilot suggestions from PR #290 – security scan, accentColor, test mock

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -57,7 +57,8 @@ jobs:
         run: |
           echo "Scanning for sensitive files in PR..."
 
-          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          # Only look at *added* files (status A) – deletions are safe
+          CHANGED_FILES=$(git diff --name-status --diff-filter=A origin/${{ github.base_ref }}...HEAD | awk '{print $2}')
 
           # Block if keystore docs or .jks files are added
           BLOCKED=$(echo "$CHANGED_FILES" | grep -E '^(keystore/|.*\.jks$|.*\.p12$|.*\.p8$|credentials\.json$|google-service-account\.json$)' || true)
@@ -69,7 +70,7 @@ jobs:
             exit 1
           fi
 
-          # Warn for internal process docs (non-blocking)
+          # Warn for internal process docs (non-blocking) — also additions only
           WARNED=$(echo "$CHANGED_FILES" | grep -E '^(docs/ANDROID_STORE_CHECKLIST\.md|docs/RELEASE_CHECKLIST\.md)' || true)
           if [ -n "$WARNED" ]; then
             echo "⚠️  WARNING: Internal process documentation modified in this PR:"

--- a/App.tsx
+++ b/App.tsx
@@ -39,7 +39,7 @@ import Animated, {
 
 SplashScreenModule.preventAutoHideAsync().catch(() => {});
 
-const APP_VERSION = '1.5.2';
+const APP_VERSION = '1.5.3';
 
 function KpiCard({
   label,

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Energy Prices Germany",
     "slug": "Energy_Price_Germany",
-    "version": "1.5.2",
+    "version": "1.5.3",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -35,7 +35,7 @@
         "backgroundColor": "#ffffff"
       },
       "package": "com.sven4321.energypricegermany",
-      "versionCode": 17,
+      "versionCode": 18,
       "permissions": [
         "INTERNET",
         "ACCESS_NETWORK_STATE",

--- a/components/charts/shared/ChartCard.tsx
+++ b/components/charts/shared/ChartCard.tsx
@@ -63,7 +63,7 @@ function ChartCardComponent({
           shadowOpacity: 0.08,
           shadowRadius: 12,
           elevation: 3,
-          ...(accentColor?.startsWith('#')
+          ...(/^#[0-9A-Fa-f]{6}$/.test(accentColor ?? '')
             ? { borderWidth: 1, borderColor: accentColor + '33' }
             : {}),
           ...style,

--- a/hooks/__tests__/usePriceAlertNotification.test.ts
+++ b/hooks/__tests__/usePriceAlertNotification.test.ts
@@ -11,7 +11,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockNotification.permission = 'granted';
   mockNotification.requestPermission = jest.fn().mockResolvedValue('granted');
-  Object.defineProperty(window, 'Notification', {
+  Object.defineProperty(globalThis, 'Notification', {
     writable: true,
     value: Object.assign(NotificationConstructor, mockNotification),
   });
@@ -85,7 +85,7 @@ describe('usePriceAlertNotification', () => {
 
   it('requests permission when default and fires on grant', async () => {
     mockNotification.permission = 'default';
-    Object.defineProperty(window, 'Notification', {
+    Object.defineProperty(globalThis, 'Notification', {
       writable: true,
       value: Object.assign(NotificationConstructor, mockNotification),
     });
@@ -111,7 +111,7 @@ describe('usePriceAlertNotification', () => {
 
   it('silently skips when permission is denied', () => {
     mockNotification.permission = 'denied';
-    Object.defineProperty(window, 'Notification', {
+    Object.defineProperty(globalThis, 'Notification', {
       writable: true,
       value: Object.assign(NotificationConstructor, mockNotification),
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "energypricegermany",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Energy price visualization for Germany with market data and renewable energy share",
   "main": "index.ts",
   "homepage": "https://s540d.github.io/Energy_Price_Germany/",


### PR DESCRIPTION
## Summary
- **security-scan.yml**: `--diff-filter=A` → nur hinzugefügte Dateien prüfen, keine Deletions (behebt false positive bei `keystore/keystores.md`-Löschung)
- **ChartCard.tsx**: `accentColor` Hex-Validierung mit `/^#[0-9A-Fa-f]{6}$/` vor Alpha-Anhang
- **usePriceAlertNotification.test.ts**: `globalThis` statt `window` für Notification-Mock (robust in node testEnvironment)

## Test plan
- [ ] Security Scan CI läuft durch (kein false positive mehr)
- [ ] `npx jest --testPathPatterns="usePriceAlertNotification"` → 6/6 grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)