### PR TITLE
Fix #292: Chart UX improvements

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -111,7 +111,6 @@ function KpiCard({
   );
 }
 
-
 function AppContent() {
   // Splash screen state
   const [showSplash, setShowSplash] = useState(true);
@@ -235,13 +234,54 @@ function AppContent() {
       return new Date(timestamp).toLocaleString(locale, {
         day: '2-digit',
         month: '2-digit',
-        year: 'numeric',
         hour: '2-digit',
         minute: '2-digit',
       });
     },
     [language]
   );
+
+  // Aggregate 15-min data to hourly for main view (avg per hour slot)
+  const hourlyEnergyData = useMemo(() => {
+    if (!filteredEnergyData.length) return filteredEnergyData;
+    const buckets = new Map<number, typeof filteredEnergyData>();
+    for (const d of filteredEnergyData) {
+      const hourTs = Math.floor(d.timestamp / 3_600_000) * 3_600_000;
+      if (!buckets.has(hourTs)) buckets.set(hourTs, []);
+      const bucket = buckets.get(hourTs);
+      if (bucket) bucket.push(d);
+    }
+    return Array.from(buckets.entries())
+      .sort(([a], [b]) => a - b)
+      .map(([hourTs, items]) => {
+        const validPrice = items.filter(i => i.marketPrice !== null);
+        const validRenewable = items.filter(i => i.renewableShare !== null);
+        const avg = <T extends number | null>(arr: T[]): T =>
+          (arr.length ? arr.reduce((s, v) => s + (v as number), 0) / arr.length : null) as T;
+        return {
+          timestamp: hourTs,
+          marketPrice: validPrice.length ? avg(validPrice.map(i => i.marketPrice as number)) : null,
+          renewableShare: validRenewable.length
+            ? avg(validRenewable.map(i => i.renewableShare as number))
+            : null,
+          renewableShareRegional: (() => {
+            const v = items.filter(
+              i => i.renewableShareRegional !== null && i.renewableShareRegional !== undefined
+            );
+            return v.length ? avg(v.map(i => i.renewableShareRegional as number)) : undefined;
+          })(),
+          isMarketPriceInterpolated: items.some(i => i.isMarketPriceInterpolated),
+          isRenewableShareInterpolated: items.some(i => i.isRenewableShareInterpolated),
+        };
+      });
+  }, [filteredEnergyData]);
+
+  // Data is stale when the newest data point is more than 2 hours old
+  const isDataStale = useMemo(() => {
+    if (!filteredEnergyData.length) return false;
+    const newest = Math.max(...filteredEnergyData.map(d => d.timestamp));
+    return Date.now() - newest > 2 * 60 * 60 * 1000;
+  }, [filteredEnergyData]);
 
   // Language, postal code, and grid fees are now managed by hooks and contexts!
 
@@ -351,11 +391,18 @@ function AppContent() {
               <Animated.View
                 style={[
                   styles.headerLiveDot,
-                  { backgroundColor: colors.accentGreen },
+                  { backgroundColor: isDataStale ? colors.accentAmber : colors.accentGreen },
                   livePulseStyle,
                 ]}
               />
-              <Text style={[styles.headerLiveLabel, { color: colors.accentGreen }]}>LIVE</Text>
+              <Text
+                style={[
+                  styles.headerLiveLabel,
+                  { color: isDataStale ? colors.accentAmber : colors.accentGreen },
+                ]}
+              >
+                LIVE
+              </Text>
             </View>
             <Text style={[styles.headerTitleLine1, { color: colors.text }]}>Energy Price</Text>
             <Text style={[styles.headerTitleLine2, { color: colors.accentGreen }]}>Germany</Text>
@@ -465,6 +512,7 @@ function AppContent() {
                 colors={colors}
                 chartType="renewable"
                 gridFees={gridFees}
+                accentColor={colors.accentGreen}
                 metrics={
                   metrics
                     ? {
@@ -506,8 +554,8 @@ function AppContent() {
                       ? `${t.renewableTitle} (${t.nationalData} & ${t.regionalData})`
                       : t.renewableTitle
                   }
-                  subtitle={`${t.timeRange}: ${filteredEnergyData.length > 0 ? formatDate(filteredEnergyData[0].timestamp) : t.loadingData} - ${filteredEnergyData.length > 0 ? formatDate(filteredEnergyData[filteredEnergyData.length - 1].timestamp) : t.loadingData}`}
-                  data={filteredEnergyData}
+                  subtitle={`${t.timeRange}: ${hourlyEnergyData.length > 0 ? formatDate(hourlyEnergyData[0].timestamp) : t.loadingData} - ${hourlyEnergyData.length > 0 ? formatDate(hourlyEnergyData[hourlyEnergyData.length - 1].timestamp) : t.loadingData}`}
+                  data={hourlyEnergyData}
                   backgroundColor={colors.surface}
                   textColor={colors.text}
                   gridColor={colors.gridLine}
@@ -530,6 +578,7 @@ function AppContent() {
                 colors={colors}
                 chartType="price"
                 gridFees={gridFees}
+                accentColor={colors.accentAmber}
                 metrics={
                   metrics
                     ? {
@@ -734,8 +783,8 @@ function AppContent() {
                   ) : (
                     <PriceBarChart
                       title={t.priceTitle}
-                      subtitle={`${t.timeRange}: ${filteredEnergyData.length > 0 ? formatDate(filteredEnergyData[0].timestamp) : t.loadingData} - ${filteredEnergyData.length > 0 ? formatDate(filteredEnergyData[filteredEnergyData.length - 1].timestamp) : t.loadingData}`}
-                      data={filteredEnergyData}
+                      subtitle={`${t.timeRange}: ${hourlyEnergyData.length > 0 ? formatDate(hourlyEnergyData[0].timestamp) : t.loadingData} - ${hourlyEnergyData.length > 0 ? formatDate(hourlyEnergyData[hourlyEnergyData.length - 1].timestamp) : t.loadingData}`}
+                      data={hourlyEnergyData}
                       backgroundColor={colors.surface}
                       textColor={colors.text}
                       gridColor={colors.gridLine}
@@ -762,6 +811,7 @@ function AppContent() {
               <CorrelationScatterChart
                 title={t.correlationTitle}
                 subtitle={`${t.timeRange}: ${filteredEnergyData.length > 0 ? formatDate(filteredEnergyData[0].timestamp) : t.loadingData} - ${filteredEnergyData.length > 0 ? formatDate(filteredEnergyData[filteredEnergyData.length - 1].timestamp) : t.loadingData}`}
+                insightText={t.correlationInsight}
                 data={filteredEnergyData}
                 backgroundColor={colors.surface}
                 textColor={colors.text}

--- a/App.tsx
+++ b/App.tsx
@@ -276,11 +276,17 @@ function AppContent() {
       });
   }, [filteredEnergyData]);
 
-  // Data is stale when the newest data point is more than 2 hours old
+  // Data is stale when the newest past data point is more than 2 hours old.
+  // Future timestamps (forecasts) are excluded so they don't mask stale live data.
   const isDataStale = useMemo(() => {
     if (!filteredEnergyData.length) return false;
-    const newest = Math.max(...filteredEnergyData.map(d => d.timestamp));
-    return Date.now() - newest > 2 * 60 * 60 * 1000;
+    const now = Date.now();
+    const pastTimestamps = filteredEnergyData
+      .map(d => d.timestamp)
+      .filter(ts => ts <= now);
+    if (!pastTimestamps.length) return false;
+    const newestPast = Math.max(...pastTimestamps);
+    return now - newestPast > 2 * 60 * 60 * 1000;
   }, [filteredEnergyData]);
 
   // Language, postal code, and grid fees are now managed by hooks and contexts!
@@ -546,6 +552,31 @@ function AppContent() {
                       </View>
                     </View>
                   ) : undefined
+                }
+                detailChildren={
+                  <RenewableBarChart
+                    title={
+                      isValidPostalCode(debouncedPostalCode) && hasRegionalData
+                        ? `${t.renewableTitle} (${t.nationalData} & ${t.regionalData})`
+                        : t.renewableTitle
+                    }
+                    subtitle={`${t.timeRange}: ${filteredEnergyData.length > 0 ? formatDate(filteredEnergyData[0].timestamp) : t.loadingData} - ${filteredEnergyData.length > 0 ? formatDate(filteredEnergyData[filteredEnergyData.length - 1].timestamp) : t.loadingData}`}
+                    data={filteredEnergyData}
+                    backgroundColor={colors.surface}
+                    textColor={colors.text}
+                    gridColor={colors.gridLine}
+                    colors={colors}
+                    labels={{
+                      yAxis: t.renewablePercent,
+                      now: t.now,
+                      average: t.average,
+                      regional: t.regionalData,
+                    }}
+                    dataKey="renewableShare"
+                    showRegionalLine={isValidPostalCode(debouncedPostalCode) && hasRegionalData}
+                    showLegend={false}
+                    accentColor={colors.accentGreen}
+                  />
                 }
               >
                 <RenewableBarChart

--- a/components/ChartDetailView.tsx
+++ b/components/ChartDetailView.tsx
@@ -48,6 +48,8 @@ interface ChartDetailViewProps {
   /** Optional override for the legend rendered inside the detail modal. */
   detailLegend?: React.ReactNode;
   gridFees?: number;
+  /** Accent color for the Details button to match chart bars */
+  accentColor?: string;
 }
 
 export function ChartDetailView({
@@ -61,6 +63,7 @@ export function ChartDetailView({
   legend,
   detailLegend,
   gridFees: _gridFees = GRID_FEES_AND_TAXES,
+  accentColor,
 }: ChartDetailViewProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [isSharing, setIsSharing] = useState(false);
@@ -210,21 +213,28 @@ export function ChartDetailView({
     </View>
   );
 
+  const detailButtonColors = accentColor
+    ? {
+        ...colors,
+        primary: accentColor,
+      }
+    : colors;
+
   return (
     <View>
-      {/* Normal view with expand button */}
-      <View>
+      {/* Normal view with expand button overlaid on chart */}
+      <View style={styles.chartWrapper}>
+        <View style={styles.chartContainer}>{children}</View>
         <View style={styles.headerContainer}>
           <Button
             variant="outlined"
             size="small"
-            colors={colors}
+            colors={detailButtonColors}
             onPress={() => setIsExpanded(true)}
           >
             Details
           </Button>
         </View>
-        <View style={styles.chartContainer}>{children}</View>
       </View>
 
       {/* Expanded detail modal */}
@@ -283,14 +293,17 @@ export function ChartDetailView({
 }
 
 const styles = StyleSheet.create({
+  chartWrapper: {
+    position: 'relative',
+  },
   chartContainer: {
-    flex: 1,
+    width: '100%',
     justifyContent: 'center',
   },
   headerContainer: {
     position: 'absolute',
-    top: 12,
-    right: 12,
+    bottom: 28,
+    right: 14,
     zIndex: 100,
   },
   modalContainer: {

--- a/components/charts/CorrelationScatterChart.tsx
+++ b/components/charts/CorrelationScatterChart.tsx
@@ -28,6 +28,7 @@ interface CorrelationScatterChartProps {
     day: string;
   };
   interactionHint?: string;
+  insightText?: string;
   accentColor?: string;
 }
 
@@ -41,6 +42,7 @@ function CorrelationScatterChartComponent({
   colors,
   labels,
   interactionHint,
+  insightText,
   accentColor,
 }: CorrelationScatterChartProps) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
@@ -434,9 +436,10 @@ function CorrelationScatterChartComponent({
           style={{
             position: 'absolute',
             left: chartWidth / 2 - 60,
-            bottom: isPhone ? 0 : 3, // Moved down by 2px for both
+            bottom: isPhone ? 0 : 3,
             fontSize: 12,
             color: textColor,
+            opacity: 0.6,
             fontWeight: '600',
           }}
         >
@@ -446,6 +449,29 @@ function CorrelationScatterChartComponent({
           {labels.yAxisPrice}
         </Text>
       </View>
+      {insightText && (
+        <View
+          style={{
+            marginTop: 10,
+            paddingHorizontal: 12,
+            paddingVertical: 8,
+            backgroundColor: colors.surfaceSecondary ?? colors.gridLine,
+            borderRadius: 10,
+            borderLeftWidth: 3,
+            borderLeftColor: colors.primary,
+          }}
+        >
+          <Text
+            style={{
+              fontSize: 12,
+              color: textColor,
+              opacity: 0.85,
+            }}
+          >
+            {insightText}
+          </Text>
+        </View>
+      )}
       {interactionHint && (
         <Text
           accessible={true}

--- a/components/charts/PriceBarChart.tsx
+++ b/components/charts/PriceBarChart.tsx
@@ -6,14 +6,7 @@ import { getYAxisLabelStyle, getPriceColor } from '../../utils/chartHelpers';
 import { GRID_FEES_AND_TAXES } from '../../utils/metrics';
 import { useChartDimensions } from '../../utils/chartUtils';
 import { useSettingsContext } from '../../context/SettingsContext';
-import {
-  ChartGrid,
-  ChartCard,
-  ChartTooltip,
-  getTooltipLeft,
-  NowMarkerLine,
-  NowMarkerLabel,
-} from './shared';
+import { ChartGrid, ChartCard, ChartTooltip, getTooltipLeft, NowMarkerLine } from './shared';
 
 interface PriceBarChartProps {
   title: string;
@@ -510,13 +503,13 @@ function PriceBarChartComponent({
           );
         })}
 
-        {/* X-axis labels */}
+        {/* X-axis labels (every 6 hours) */}
         {(() => {
           const labels = [];
           const startDate = new Date(minTime);
           const endDate = new Date(maxTime);
 
-          const startHour = Math.ceil(startDate.getHours() / 3) * 3;
+          const startHour = Math.ceil(startDate.getHours() / 6) * 6;
           const current = new Date(startDate);
           current.setHours(startHour, 0, 0, 0);
 
@@ -544,26 +537,11 @@ function PriceBarChartComponent({
               </Text>
             );
 
-            current.setHours(current.getHours() + 3);
+            current.setHours(current.getHours() + 6);
           }
 
           return labels;
         })()}
-
-        {/* "Jetzt" Label */}
-        {now >= minTime && now <= maxTime && (
-          <NowMarkerLabel
-            now={now}
-            minTime={minTime}
-            timeRange={timeRange}
-            chartWidth={chartWidth}
-            chartHeight={chartHeight}
-            leftPadding={leftPadding}
-            rightPadding={rightPadding}
-            bottomPadding={bottomPadding}
-            label={labels.now}
-          />
-        )}
 
         {/* End-of-chart label */}
         <Text

--- a/components/charts/RenewableBarChart.tsx
+++ b/components/charts/RenewableBarChart.tsx
@@ -4,14 +4,7 @@ import Svg, { Rect, Line, Polyline } from 'react-native-svg';
 import type { ThemeColors } from '../../utils/theme';
 import { getYAxisLabelStyle } from '../../utils/chartHelpers';
 import { useChartDimensions } from '../../utils/chartUtils';
-import {
-  ChartGrid,
-  ChartCard,
-  ChartTooltip,
-  getTooltipLeft,
-  NowMarkerLine,
-  NowMarkerLabel,
-} from './shared';
+import { ChartGrid, ChartCard, ChartTooltip, getTooltipLeft, NowMarkerLine } from './shared';
 
 // Performance: Move color helpers outside component for stable references
 const interpolateColor = (color1: number[], color2: number[], factor: number) => {
@@ -579,13 +572,13 @@ function RenewableBarChartComponent({
           );
         })}
 
-        {/* X-axis labels (alle 3 Stunden) */}
+        {/* X-axis labels (every 6 hours) */}
         {(() => {
           const labels = [];
           const startDate = new Date(minTime);
           const endDate = new Date(maxTime);
 
-          const startHour = Math.ceil(startDate.getHours() / 3) * 3;
+          const startHour = Math.ceil(startDate.getHours() / 6) * 6;
           const current = new Date(startDate);
           current.setHours(startHour, 0, 0, 0);
 
@@ -612,26 +605,11 @@ function RenewableBarChartComponent({
               </Text>
             );
 
-            current.setHours(current.getHours() + 3);
+            current.setHours(current.getHours() + 6);
           }
 
           return labels;
         })()}
-
-        {/* "Jetzt" Label */}
-        {now >= minTime && now <= maxTime && (
-          <NowMarkerLabel
-            now={now}
-            minTime={minTime}
-            timeRange={timeRange}
-            chartWidth={chartWidth}
-            chartHeight={chartHeight}
-            leftPadding={leftPadding}
-            rightPadding={rightPadding}
-            bottomPadding={bottomPadding}
-            label={labels.now}
-          />
-        )}
 
         {/* Y-Achsen-Label */}
         <Text style={getYAxisLabelStyle(chartHeight, -15, textColor, isPhone)}>{labels.yAxis}</Text>

--- a/utils/chartHelpers.test.ts
+++ b/utils/chartHelpers.test.ts
@@ -89,6 +89,7 @@ describe('chartHelpers.ts', () => {
           top: 100, // chartHeight / 2
           fontSize: 12,
           color: '#333',
+          opacity: 0.6,
           fontWeight: '600',
           transform: [{ rotate: '-90deg' }],
           width: 200,
@@ -142,6 +143,7 @@ describe('chartHelpers.ts', () => {
           top: 110, // 200 / 2 + 10
           fontSize: 12,
           color: '#00FF00',
+          opacity: 0.6,
           fontWeight: '600',
           transform: [{ rotate: '-90deg' }],
           width: 200,
@@ -189,6 +191,7 @@ describe('chartHelpers.ts', () => {
           top: 175, // 300 / 2 + 25
           fontSize: 12,
           color: '#123456',
+          opacity: 0.6,
           fontWeight: '600',
           transform: [{ rotate: '-90deg' }],
           width: 200,

--- a/utils/chartHelpers.ts
+++ b/utils/chartHelpers.ts
@@ -61,10 +61,11 @@ export function getYAxisLabelStyle(
 
   return {
     position: 'absolute' as const,
-    left: leftOffset, // Responsiver Abstand vom oberen Rand
+    left: leftOffset,
     top: getYAxisLabelCenterPosition(chartHeight, horizontalOffset),
     fontSize: 12,
     color: textColor,
+    opacity: 0.6,
     fontWeight: '600' as const,
     transform: [{ rotate: '-90deg' }],
     width: 200,

--- a/utils/translations.ts
+++ b/utils/translations.ts
@@ -87,6 +87,7 @@ export const translations = {
     renewableTitle: 'Share of Renewable Energy in Load',
     priceTitle: 'Market and End Customer Electricity Price',
     correlationTitle: 'Correlation: Price vs. Renewables',
+    correlationInsight: '💡 High renewable share correlates with lower market prices',
     timeRange: 'Time Range',
     noData: 'No data available',
     noDataMessage: 'The energy data could not be loaded. Please try again later.',
@@ -210,6 +211,7 @@ export const translations = {
     renewableTitle: 'Anteil Erneuerbarer Energien an der Last',
     priceTitle: 'Börsen- und Endkundenstrompreis',
     correlationTitle: 'Korrelation: Preis vs. Erneuerbare',
+    correlationInsight: '💡 Hoher Erneuerbaren-Anteil korreliert mit niedrigem Börsenpreis',
     timeRange: 'Zeitraum',
     noData: 'Keine Daten verfügbar',
     noDataMessage:


### PR DESCRIPTION
## Summary

Implements all UX improvements from Issue #292:

- **Kein Jahreszahl** im Subtitle – nur Tag, Monat, Uhrzeit
- **1 Balken/Stunde** auf der Hauptseite (Aggregation von 15-min → stündlich); Detailansicht behält volle 15-min-Auflösung
- **Stundenbeschriftung alle 6h** statt alle 3h (weniger Gedränge)
- **"Jetzt"-Label entfernt** – roter Strich bleibt erhalten
- **Achsentitel (Y-Achse)** gleiche Opacity (0.6) wie die Zahlenbeschriftungen
- **Details-Button in die Box** – absolut unten rechts auf dem Chart positioniert (wie im Screenshot der Vorlage)
- **Details-Button Farbe** passend zum Balken-Accent (grün beim Erneuerbare-Chart, amber beim Preis-Chart)
- **Korrelationsgraph Info-Box** – abgesetztes Textfenster mit Border statt Plain-Italic-Text
- **LIVE-Dot wird orange** wenn die neuesten Daten älter als 2 Stunden sind

## Test plan

- [ ] Charts zeigen auf Hauptseite nur stündliche Balken (24 Balken statt 96)
- [ ] Detailansicht öffnet mit voller 15-min-Auflösung
- [ ] X-Achse zeigt 0h, 6h, 12h, 18h, 24h
- [ ] Kein "Jetzt"-Label, roter Strich noch sichtbar
- [ ] Details-Button liegt unten rechts auf dem Chart
- [ ] LIVE-Dot orange wenn Daten alt (manuell testbar via Mock)
- [ ] Korrelationsgraph zeigt Info-Box unten

🤖 Generated with [Claude Code](https://claude.ai/claude-code)