### PR TITLE
Fix #271: harden Cloudflare worker (origin whitelist, PLZ validation, cache key)

### DIFF
--- a/cloudflare-worker.js
+++ b/cloudflare-worker.js
@@ -1,41 +1,73 @@
+// Allowed origins for CORS – only our own deployments and local dev
+const ALLOWED_ORIGINS = [
+  'https://s540d.github.io',
+  'http://localhost:8080',
+  'http://localhost:19006',
+  'http://localhost:8081',
+];
+
+// German postal code: exactly 5 digits
+const PLZ_PATTERN = /^\d{5}$/;
+
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
-    const plz = url.searchParams.get('plz');
+    const origin = request.headers.get('Origin') || '';
 
-    // CORS Headers - Erlaubt Zugriff von überall
+    // Determine CORS origin: allow only our known origins
+    const allowedOrigin = ALLOWED_ORIGINS.includes(origin) ? origin : null;
+
     const corsHeaders = {
-      'Access-Control-Allow-Origin': '*',
       'Access-Control-Allow-Methods': 'GET, HEAD, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type',
+      ...(allowedOrigin ? { 'Access-Control-Allow-Origin': allowedOrigin } : {}),
     };
 
-    // Handle OPTIONS request (Preflight) - Wichtig für CORS
+    // Reject preflight from unknown origins
     if (request.method === 'OPTIONS') {
+      if (!allowedOrigin) {
+        return new Response('Forbidden', { status: 403 });
+      }
       return new Response(null, { headers: corsHeaders });
     }
+
+    // Only GET requests
+    if (request.method !== 'GET' && request.method !== 'HEAD') {
+      return new Response('Method Not Allowed', { status: 405, headers: corsHeaders });
+    }
+
+    // Reject requests from unknown origins (browser requests always carry Origin)
+    if (!allowedOrigin) {
+      return new Response('Forbidden', { status: 403 });
+    }
+
+    const plz = url.searchParams.get('plz');
 
     if (!plz) {
       return new Response('Missing "plz" parameter', { status: 400, headers: corsHeaders });
     }
 
-    // Cache Key generation
-    const cacheUrl = new URL(request.url);
-    const cacheKey = new Request(cacheUrl.toString(), request);
+    // Validate PLZ format before forwarding to upstream
+    if (!PLZ_PATTERN.test(plz)) {
+      return new Response('Invalid "plz" parameter: must be exactly 5 digits', { status: 400, headers: corsHeaders });
+    }
+
+    // Cache Key generation (use only the canonical URL to avoid cache poisoning)
+    const cacheUrl = new URL(`https://worker-cache/signal?plz=${plz}`);
+    const cacheKey = new Request(cacheUrl.toString());
     const cache = caches.default;
 
-    // 1. Prüfen ob Daten im Cloudflare Cache liegen
+    // 1. Check Cloudflare cache
     let response = await cache.match(cacheKey);
     if (response) {
-      // Response neu verpacken um sicherzustellen, dass CORS Header da sind
       const newResponse = new Response(response.body, response);
-      newResponse.headers.set('Access-Control-Allow-Origin', '*');
+      newResponse.headers.set('Access-Control-Allow-Origin', allowedOrigin);
       return newResponse;
     }
 
-    // 2. Daten von Energy Charts holen
+    // 2. Fetch from Energy Charts
     const targetUrl = `https://api.energy-charts.info/signal?country=de&postal_code=${plz}`;
-    
+
     try {
       const apiResponse = await fetch(targetUrl, {
         headers: {
@@ -49,17 +81,17 @@ export default {
 
       const data = await apiResponse.json();
 
-      // 3. Antwort erstellen mit Caching-Headern
+      // 3. Build response with cache headers
       response = new Response(JSON.stringify(data), {
         headers: {
           ...corsHeaders,
           'Content-Type': 'application/json',
-          // Browser-Cache: 15 Min (900s), Cloudflare-Cache: 1 Stunde (3600s)
-          'Cache-Control': 'public, max-age=900, s-maxage=3600', 
+          // Browser cache: 15 min, Cloudflare edge cache: 1 hour
+          'Cache-Control': 'public, max-age=900, s-maxage=3600',
         },
       });
 
-      // 4. In den Cloudflare Cache speichern (asynchron)
+      // 4. Store in Cloudflare cache (async)
       ctx.waitUntil(cache.put(cacheKey, response.clone()));
 
       return response;


### PR DESCRIPTION
## Problem
The Cloudflare worker was an open CORS proxy: any origin could send arbitrary `plz` values, flooding our Cloudflare quota and the upstream Energy Charts API.

## Changes

### Origin Whitelist
Only requests from known origins receive CORS headers and a valid response:
- `https://s540d.github.io` (production)
- `http://localhost:8080`, `:19006`, `:8081` (local dev)

Unknown origins get `403 Forbidden`. Preflight (`OPTIONS`) from unknown origins is also blocked.

### PLZ Validation
The `plz` parameter is validated against `/^\d{5}$/` before the upstream URL is constructed. Invalid values return `400 Bad Request` without any upstream call.

### Canonical Cache Key
The cache key is now a normalized URL (`worker-cache/signal?plz=XXXXX`) instead of the raw request URL. This prevents cache poisoning via crafted request URLs with extra parameters.

### Method Restriction
Only `GET` and `HEAD` are accepted. All other methods return `405 Method Not Allowed`.

## What's not yet done (follow-up)
IP-based rate limiting requires a **Cloudflare KV binding** configured in the Worker dashboard. This can be added once a KV namespace is provisioned — no code changes needed here, just a KV lookup on a per-IP counter.

## Deployment
The worker is deployed manually via the Cloudflare dashboard. The updated `cloudflare-worker.js` is ready to paste/upload after this PR is merged to main.

Closes #271
Part of #301