### PR TITLE
feat: Vergleich mit Vorperiode in der Verlauf-Ansicht (#311)

### DIFF
--- a/components/HistoricalDataView.tsx
+++ b/components/HistoricalDataView.tsx
@@ -15,7 +15,12 @@ import { getThemeColors } from '../utils/theme';
 import { useSettingsContext } from '../context/SettingsContext';
 import { historicalDataStore } from '../services/historicalDataStore';
 import { aggregateEnergyData } from '../utils/dataAggregation';
-import { computeHistoricalStats, type SeriesStat } from '../utils/historicalStats';
+import {
+  computeHistoricalStats,
+  computePeriodComparison,
+  type SeriesStat,
+  type SeriesComparison,
+} from '../utils/historicalStats';
 import type { EnergyData } from '../utils/metrics';
 import { PriceBarChart } from './charts/PriceBarChart';
 import { RenewableBarChart } from './charts/RenewableBarChart';
@@ -66,6 +71,7 @@ export function HistoricalDataView({
 
   const [timeRange, setTimeRange] = useState<TimeRange>('24h');
   const [rangeData, setRangeData] = useState<EnergyData[]>([]);
+  const [previousData, setPreviousData] = useState<EnergyData[]>([]);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
@@ -75,8 +81,15 @@ export function HistoricalDataView({
     async function load() {
       setLoading(true);
       const now = Date.now();
-      const from = now - RANGE_WINDOW_MS[timeRange];
-      const historical = await historicalDataStore.getRange(from, now);
+      const window = RANGE_WINDOW_MS[timeRange];
+      const from = now - window;
+      const prevFrom = from - window;
+
+      // Aktuelle Periode (Cache + Server-Fallback) und Vorperiode parallel laden
+      const [historical, previousHistorical] = await Promise.all([
+        historicalDataStore.getRange(from, now),
+        historicalDataStore.getRange(prevFrom, from),
+      ]);
       if (cancelled) return;
 
       // Cache + Live mergen (Live gewinnt per Timestamp), nur ab "from".
@@ -89,7 +102,13 @@ export function HistoricalDataView({
         .filter(d => d.timestamp >= from)
         .sort((a, b) => a.timestamp - b.timestamp);
 
+      // Vorperiode: [prevFrom, from) – Grenze "from" gehört zur aktuellen Periode
+      const previous = previousHistorical
+        .filter(d => d.timestamp >= prevFrom && d.timestamp < from)
+        .sort((a, b) => a.timestamp - b.timestamp);
+
       setRangeData(merged);
+      setPreviousData(previous);
       setLoading(false);
     }
 
@@ -105,6 +124,10 @@ export function HistoricalDataView({
   }, [rangeData, timeRange]);
 
   const stats = useMemo(() => computeHistoricalStats(rangeData), [rangeData]);
+  const comparison = useMemo(
+    () => computePeriodComparison(rangeData, previousData),
+    [rangeData, previousData]
+  );
 
   const priceLabels = {
     yAxis: t.pricePerKwh,
@@ -195,6 +218,7 @@ export function HistoricalDataView({
               <StatBlock
                 title={t.historyPriceSection}
                 stat={stats.price}
+                comparison={comparison.price}
                 unit="¢"
                 colors={colors}
                 t={t}
@@ -202,6 +226,7 @@ export function HistoricalDataView({
               <StatBlock
                 title={t.historyRenewableSection}
                 stat={stats.renewable}
+                comparison={comparison.renewable}
                 unit="%"
                 colors={colors}
                 t={t}
@@ -251,15 +276,26 @@ function trendLabel(stat: SeriesStat, t: Record<string, string>): string {
   return `→ ${t.historyTrendFlat}`;
 }
 
+/** "↑ +2.3 ¢ (+12.5%)" – Veränderung des Durchschnitts ggü. Vorperiode (#311). */
+function comparisonLabel(c: SeriesComparison, unit: string): string {
+  const arrow = c.direction === 'up' ? '↑' : c.direction === 'down' ? '↓' : '→';
+  const absSign = c.deltaAbs >= 0 ? '+' : '-';
+  const absStr = `${absSign}${Math.abs(c.deltaAbs).toFixed(1)} ${unit}`;
+  if (c.deltaPct === null) return `${arrow} ${absStr}`;
+  const pctSign = c.deltaPct >= 0 ? '+' : '-';
+  return `${arrow} ${absStr} (${pctSign}${Math.abs(c.deltaPct).toFixed(1)}%)`;
+}
+
 interface StatBlockProps {
   title: string;
   stat: SeriesStat | null;
+  comparison: SeriesComparison | null;
   unit: string;
   colors: ReturnType<typeof getThemeColors>;
   t: Record<string, string>;
 }
 
-function StatBlock({ title, stat, unit, colors, t }: StatBlockProps) {
+function StatBlock({ title, stat, comparison, unit, colors, t }: StatBlockProps) {
   if (!stat) return null;
   const fmt = (v: number) => `${v.toFixed(1)} ${unit}`;
   const rows: Array<[string, string]> = [
@@ -269,6 +305,9 @@ function StatBlock({ title, stat, unit, colors, t }: StatBlockProps) {
     [t.historyStatMedian, fmt(stat.median)],
     [t.historyStatTrend, trendLabel(stat, t)],
   ];
+  if (comparison) {
+    rows.push([t.historyStatVsPrev, comparisonLabel(comparison, unit)]);
+  }
   return (
     <View style={styles.statBlock}>
       <Text style={[styles.statBlockTitle, { color: colors.textSecondary }]}>{title}</Text>

--- a/utils/historicalStats.test.ts
+++ b/utils/historicalStats.test.ts
@@ -1,4 +1,4 @@
-import { computeHistoricalStats } from './historicalStats';
+import { computeHistoricalStats, computePeriodComparison } from './historicalStats';
 import type { EnergyData } from './metrics';
 
 function point(ts: number, marketPrice: number | null, renewableShare: number | null): EnergyData {
@@ -64,5 +64,51 @@ describe('computeHistoricalStats', () => {
     const stats = computeHistoricalStats(data);
     expect(stats.price?.trend).toBe('flat');
     expect(stats.renewable?.trend).toBe('flat');
+  });
+});
+
+describe('computePeriodComparison', () => {
+  it('returns null series when a period has no data', () => {
+    const result = computePeriodComparison([point(1000, 100, 40)], []);
+    expect(result.price).toBeNull();
+    expect(result.renewable).toBeNull();
+  });
+
+  it('computes absolute and percentage delta of the averages', () => {
+    // current price avg (¢/kWh): (10 + 30)/2 = 20 ; previous: (10 + 10)/2 = 10
+    const current = [point(3000, 100, 60), point(4000, 300, 80)];
+    const previous = [point(1000, 100, 40), point(2000, 100, 40)];
+    const result = computePeriodComparison(current, previous);
+
+    expect(result.price?.currentAvg).toBeCloseTo(20);
+    expect(result.price?.previousAvg).toBeCloseTo(10);
+    expect(result.price?.deltaAbs).toBeCloseTo(10);
+    expect(result.price?.deltaPct).toBeCloseTo(100);
+    expect(result.price?.direction).toBe('up');
+
+    // renewable: current avg 70, previous 40 -> +30, +75%
+    expect(result.renewable?.deltaAbs).toBeCloseTo(30);
+    expect(result.renewable?.deltaPct).toBeCloseTo(75);
+    expect(result.renewable?.direction).toBe('up');
+  });
+
+  it('reports a downward direction', () => {
+    const current = [point(3000, 100, 30)];
+    const previous = [point(1000, 300, 90)];
+    const result = computePeriodComparison(current, previous);
+    expect(result.price?.direction).toBe('down');
+    expect(result.renewable?.direction).toBe('down');
+  });
+
+  it('reports flat for sub-0.5% change and null deltaPct when previous avg is 0', () => {
+    const current = [point(3000, 1000, 50.1)];
+    const previous = [point(1000, 1000, 50.0)];
+    const flat = computePeriodComparison(current, previous);
+    expect(flat.price?.direction).toBe('flat');
+
+    // previous renewable avg 0 -> deltaPct null, direction by absolute sign
+    const zeroPrev = computePeriodComparison([point(2, 100, 5)], [point(1, 100, 0)]);
+    expect(zeroPrev.renewable?.deltaPct).toBeNull();
+    expect(zeroPrev.renewable?.direction).toBe('up');
   });
 });

--- a/utils/historicalStats.ts
+++ b/utils/historicalStats.ts
@@ -72,6 +72,81 @@ function computeSeries(points: Point[]): SeriesStat | null {
 }
 
 /**
+ * Vergleich einer Serie (Preis oder Erneuerbare) zwischen aktueller und
+ * vorangegangener Periode (Issue #311).
+ */
+export interface SeriesComparison {
+  currentAvg: number;
+  previousAvg: number;
+  /** currentAvg - previousAvg (gleiche Einheit wie die Serie). */
+  deltaAbs: number;
+  /** Prozentuale Veränderung; null, wenn previousAvg == 0. */
+  deltaPct: number | null;
+  direction: Trend;
+}
+
+export interface PeriodComparison {
+  /** Preis in ¢/kWh; null, wenn eine der Perioden keine Preisdaten hat. */
+  price: SeriesComparison | null;
+  /** Erneuerbaren-Anteil in %; null, wenn eine Periode keine Daten hat. */
+  renewable: SeriesComparison | null;
+}
+
+/** Extrahiert Preis- (¢/kWh) und Erneuerbaren-Werte aus EnergyData[]. */
+function extractValues(data: EnergyData[]): { price: number[]; renewable: number[] } {
+  const price: number[] = [];
+  const renewable: number[] = [];
+  for (const d of data) {
+    if (d.marketPrice !== null && d.marketPrice !== undefined) {
+      price.push(d.marketPrice * 0.1);
+    }
+    if (d.renewableShare !== null && d.renewableShare !== undefined) {
+      renewable.push(d.renewableShare);
+    }
+  }
+  return { price, renewable };
+}
+
+function compareSeries(current: number[], previous: number[]): SeriesComparison | null {
+  if (current.length === 0 || previous.length === 0) return null;
+
+  const currentAvg = average(current);
+  const previousAvg = average(previous);
+  const deltaAbs = currentAvg - previousAvg;
+  const deltaPct = previousAvg !== 0 ? (deltaAbs / Math.abs(previousAvg)) * 100 : null;
+
+  // "flat" bei < 0.5% Änderung (bzw. ~0 absolut, falls previousAvg == 0)
+  let direction: Trend = 'flat';
+  if (deltaPct !== null) {
+    if (deltaPct > 0.5) direction = 'up';
+    else if (deltaPct < -0.5) direction = 'down';
+  } else if (deltaAbs > 1e-9) {
+    direction = 'up';
+  } else if (deltaAbs < -1e-9) {
+    direction = 'down';
+  }
+
+  return { currentAvg, previousAvg, deltaAbs, deltaPct, direction };
+}
+
+/**
+ * Vergleicht die aktuelle Periode mit der unmittelbar vorangegangenen,
+ * gleich langen Periode (Issue #311). Liefert je Serie die Veränderung des
+ * Durchschnitts (absolut + prozentual) oder null, wenn Daten fehlen.
+ */
+export function computePeriodComparison(
+  current: EnergyData[],
+  previous: EnergyData[]
+): PeriodComparison {
+  const cur = extractValues(current);
+  const prev = extractValues(previous);
+  return {
+    price: compareSeries(cur.price, prev.price),
+    renewable: compareSeries(cur.renewable, prev.renewable),
+  };
+}
+
+/**
  * Berechnet Preis- und Erneuerbaren-Statistiken über den gegebenen Datensatz.
  * Preis wird in ¢/kWh ausgegeben (Marktpreis * 0.1).
  */

--- a/utils/translations.ts
+++ b/utils/translations.ts
@@ -301,6 +301,7 @@ export const translations = {
     historyStatsTitle: 'Statistik',
     historyStatMedian: 'Median',
     historyStatTrend: 'Trend',
+    historyStatVsPrev: 'vs. Vorperiode',
     historyTrendUp: 'steigend',
     historyTrendDown: 'fallend',
     historyTrendFlat: 'stabil',

--- a/utils/translations.ts
+++ b/utils/translations.ts
@@ -146,6 +146,7 @@ export const translations = {
     historyStatsTitle: 'Statistics',
     historyStatMedian: 'Median',
     historyStatTrend: 'Trend',
+    historyStatVsPrev: 'vs. previous period',
     historyTrendUp: 'rising',
     historyTrendDown: 'falling',
     historyTrendFlat: 'stable',


### PR DESCRIPTION
Setzt **#311** um (Folge aus #3): Vergleich mit der Vorperiode in der Verlauf-Ansicht.

## Änderungen
- **`utils/historicalStats.ts`** – neue reine Funktion `computePeriodComparison(current, previous)`:
  - liefert je Serie (Preis ¢/kWh, Erneuerbare %) `currentAvg`, `previousAvg`, `deltaAbs`, `deltaPct` und `direction` (`up`/`down`/`flat`, Schwelle 0,5 %).
  - `null`, wenn eine der Perioden keine Daten hat; `deltaPct` ist `null`, wenn `previousAvg == 0`.
- **`components/HistoricalDataView.tsx`** – lädt zusätzlich die gleich lange **Vorperiode** `[from - window, from)` parallel über `historicalDataStore.getRange` (Server-Fallback greift für ältere Tage automatisch) und zeigt je Statistik-Block eine **„vs. Vorperiode"**-Zeile: Pfeil + Δ absolut + (Δ %), z. B. `↑ +2,3 ¢ (+12,5%)`.
- **`utils/translations.ts`** – `historyStatVsPrev` (DE/EN).
- **Tests** – Unit-Tests für `computePeriodComparison` (Delta abs/%, Richtung up/down/flat, leere und 0-Vorperiode).

## Edge Cases (aus #311)
- Leere Vorperiode → Zeile wird nicht angezeigt (statt 0/NaN).
- `previousAvg == 0` → kein Prozentwert, Richtung über absolutes Vorzeichen.
- Berlin-Tagesschlüssel: über `historicalDataStore.getRange` abgedeckt.

## Test
- `npm test`: 281 Tests grün. `tsc`: keine neuen Fehler. ESLint: keine Fehler.

Closes #311.

🤖 Erstellt mit Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01782euxwgYRFJKjtnhx9JtF)_