### PR TITLE
feat(#7): Standards-Audit-Listener (Pilot für Cross-Project Standardisierung)

### DIFF
--- a/.github/workflows/standards-audit.yml
+++ b/.github/workflows/standards-audit.yml
@@ -1,0 +1,33 @@
+name: Standards Audit
+
+# Konsumiert die zentralen Reusable Workflows aus project-templates (Issue #7).
+# Läuft bei:
+#   - PRs (Audits gaten Code-Änderungen)
+#   - weekly-self-audit Dispatch (von project-templates/weekly-audit.yml, Mo 08:00)
+#   - manuell (workflow_dispatch)
+#
+# Alle uses-Referenzen sind auf @v1 gepinnt (nie @main – Issue #7, Punkt 1).
+
+on:
+  pull_request:
+    branches: [main, staging, testing]
+  repository_dispatch:
+    types: [weekly-self-audit]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  security-scan:
+    uses: S540d/project-templates/.github/workflows/reusable-security-scan.yml@v1
+    with:
+      fail_on_findings: true
+
+  gitignore-audit:
+    uses: S540d/project-templates/.github/workflows/reusable-gitignore-audit.yml@v1
+    with:
+      fail_on_missing: true
+
+  dev-standards-audit:
+    uses: S540d/project-templates/.github/workflows/reusable-dev-standards-audit.yml@v1

--- a/.github/workflows/standards-audit.yml
+++ b/.github/workflows/standards-audit.yml
@@ -20,14 +20,14 @@ permissions:
 
 jobs:
   security-scan:
-    uses: S540d/project-templates/.github/workflows/reusable-security-scan.yml@v1
+    uses: S540d/project-templates/.github/workflows/reusable-security-scan.yml@10eb4dfae35ce008e1134fde4235972be8d8922e
     with:
       fail_on_findings: true
 
   gitignore-audit:
-    uses: S540d/project-templates/.github/workflows/reusable-gitignore-audit.yml@v1
+    uses: S540d/project-templates/.github/workflows/reusable-gitignore-audit.yml@10eb4dfae35ce008e1134fde4235972be8d8922e
     with:
       fail_on_missing: true
 
   dev-standards-audit:
-    uses: S540d/project-templates/.github/workflows/reusable-dev-standards-audit.yml@v1
+    uses: S540d/project-templates/.github/workflows/reusable-dev-standards-audit.yml@10eb4dfae35ce008e1134fde4235972be8d8922e

--- a/.github/workflows/standards-audit.yml
+++ b/.github/workflows/standards-audit.yml
@@ -20,14 +20,14 @@ permissions:
 
 jobs:
   security-scan:
-    uses: S540d/project-templates/.github/workflows/reusable-security-scan.yml@10eb4dfae35ce008e1134fde4235972be8d8922e
+    uses: S540d/project-templates/.github/workflows/reusable-security-scan.yml@v1
     with:
       fail_on_findings: true
 
   gitignore-audit:
-    uses: S540d/project-templates/.github/workflows/reusable-gitignore-audit.yml@10eb4dfae35ce008e1134fde4235972be8d8922e
+    uses: S540d/project-templates/.github/workflows/reusable-gitignore-audit.yml@v1
     with:
       fail_on_missing: true
 
   dev-standards-audit:
-    uses: S540d/project-templates/.github/workflows/reusable-dev-standards-audit.yml@10eb4dfae35ce008e1134fde4235972be8d8922e
+    uses: S540d/project-templates/.github/workflows/reusable-dev-standards-audit.yml@v1

--- a/.github/workflows/standards-audit.yml
+++ b/.github/workflows/standards-audit.yml
@@ -1,12 +1,13 @@
 name: Standards Audit
 
-# Konsumiert die zentralen Reusable Workflows aus project-templates (Issue #7).
+# Konsumiert die zentralen Reusable Workflows aus project-templates
+# (S540d/project-templates#7 – Cross-Project-Standardisierung).
 # Läuft bei:
 #   - PRs (Audits gaten Code-Änderungen)
 #   - weekly-self-audit Dispatch (von project-templates/weekly-audit.yml, Mo 08:00)
 #   - manuell (workflow_dispatch)
 #
-# Alle uses-Referenzen sind auf @v1 gepinnt (nie @main – Issue #7, Punkt 1).
+# Alle uses-Referenzen sind auf @v1 gepinnt (nie @main – S540d/project-templates#7, Punkt 1).
 
 on:
   pull_request:
@@ -29,5 +30,9 @@ jobs:
     with:
       fail_on_missing: true
 
+  # Rein informativ: der Audit-Step im Reusable Workflow ist intern non-blocking
+  # (läuft auch bei Abweichungen grün durch). Ein job-level continue-on-error ist
+  # auf uses:-Jobs nicht erlaubt – die Non-Blocking-Semantik muss daher im Template
+  # bleiben; security-scan und gitignore-audit (fail_on_*: true) gaten den Merge.
   dev-standards-audit:
     uses: S540d/project-templates/.github/workflows/reusable-dev-standards-audit.yml@v1

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ expo-env.d.ts
 .kotlin/
 *.orig.*
 *.jks
+*.keystore
 *.p8
 *.p12
 *.key
@@ -39,7 +40,9 @@ yarn-error.*
 .DS_Store
 *.pem
 
-# local env files
+# local env files (Geheimnisse – nie committen; .env.<environment> mit Public-Config ist ok)
+.env
+.env.local
 .env*.local
 
 # typescript


### PR DESCRIPTION
**Pilot** für die zentrale Cross-Project Standardisierung (project-templates Issue #7). EnergyPriceGermany ist das erste Repo, das die Reusable Workflows konsumiert.

## Änderungen
- **`.github/workflows/standards-audit.yml`** – konsumiert die zentralen Reusable Workflows (alle auf **`@v1`** gepinnt):
  - `reusable-security-scan.yml` (fail-closed)
  - `reusable-gitignore-audit.yml` (blocking)
  - `reusable-dev-standards-audit.yml` (non-blocking)
  - Trigger: PRs (gaten Code), `weekly-self-audit` Dispatch (Mo 08:00 von project-templates), manuell
- **`.gitignore`** – `*.keystore`, `.env`, `.env.local` ergänzt (Pflicht-Einträge des Audits). Committete `.env.production/.staging/.testing` (reine Public-Config) bleiben getrackt.

## Vorab verifiziert (gegen die @v1-Audits)
- gitignore-audit: alle Pflicht-Einträge vorhanden, keine truly-sensitive Dateien getrackt, `.env.<env>`-Allowlist (nur `EXPO_PUBLIC_*`/`EXPO_ENV`/`NODE_ENV`) erfüllt ✅
- security-scan: keine Token-Funde, keine sensiblen Dateien; Fingerprint-Check entfällt (öffentliche Hashes) ✅

## Hinweis
- `weekly-audit.yml` (zentral) braucht noch das Secret `ORG_AUTOMATION_TOKEN`, um den Dispatch auszulösen. Der Listener hier funktioniert unabhängig davon bei PRs/manuell.
- Nach Bewährung: Rollout auf die übrigen 6 Repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)