### PR TITLE
ci(#16): Remove staging from all workflow triggers (EnergyPriceGermany)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,9 +2,9 @@ name: CI/CD - Automated Quality Checks
 
 on:
   push:
-    branches: [main, develop, staging, testing]
+    branches: [main, testing]
   pull_request:
-    branches: [main, develop, staging, testing]
+    branches: [main, testing]
 
 # Security: Explicitly set minimal permissions
 permissions:

--- a/.github/workflows/deploy-unified.yml
+++ b/.github/workflows/deploy-unified.yml
@@ -1,9 +1,9 @@
 name: Deploy (Unified)
 
 on:
-  # Automatic trigger on push to main, staging, testing
+  # Automatic trigger on push to main, testing
   push:
-    branches: [ main, staging, testing ]
+    branches: [ main, testing ]
   # Fallback: Scheduled deployment every 6 hours for main branch
   schedule:
     - cron: '0 4,11,16,18,21 * * *'
@@ -36,11 +36,6 @@ jobs:
               echo "EXPO_ENV=production" >> $GITHUB_OUTPUT
               echo "TARGET_FOLDER=." >> $GITHUB_OUTPUT
               echo "URL=https://s540d.github.io/Energy_Price_Germany/" >> $GITHUB_OUTPUT
-              ;;
-            "refs/heads/staging")
-              echo "EXPO_ENV=staging" >> $GITHUB_OUTPUT
-              echo "TARGET_FOLDER=staging" >> $GITHUB_OUTPUT
-              echo "URL=https://s540d.github.io/Energy_Price_Germany/staging/" >> $GITHUB_OUTPUT
               ;;
             "refs/heads/testing")
               echo "EXPO_ENV=testing" >> $GITHUB_OUTPUT
@@ -101,7 +96,7 @@ jobs:
 
             # Save other environment folders
             PRESERVED_FOLDERS=()
-            for folder in staging testing; do
+            for folder in testing; do
               if [ -d "$folder" ]; then
                 PRESERVED_FOLDERS+=("$folder")
                 mv "$folder" "$folder.bak"

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -2,7 +2,7 @@ name: Security Scan
 
 on:
   pull_request:
-    branches: [main, staging, testing]
+    branches: [main, testing]
 
 permissions:
   contents: read

--- a/.github/workflows/standards-audit.yml
+++ b/.github/workflows/standards-audit.yml
@@ -11,7 +11,7 @@ name: Standards Audit
 
 on:
   pull_request:
-    branches: [main, staging, testing]
+    branches: [main, testing]
   repository_dispatch:
     types: [weekly-self-audit]
   workflow_dispatch: {}


### PR DESCRIPTION
## Summary
- New branch strategy: `main` + `testing` only (no `staging`)
- `staging` branch deleted on remote
- All workflow triggers updated: `[main, staging, testing]` → `[main, testing]`
- `deploy-unified.yml`: staging case block removed, preserved folders loop updated

## Files changed
- `.github/workflows/ci-cd.yml`
- `.github/workflows/deploy-unified.yml`
- `.github/workflows/security-scan.yml`
- `.github/workflows/standards-audit.yml`

Part of project-templates#16.