### PR TITLE
fix(fetch): allow renewable share > 100% (solar overproduction)

### DIFF
--- a/scripts/merge-market-data.js
+++ b/scripts/merge-market-data.js
@@ -21,9 +21,14 @@ function detectAnomalies(data, sourceName = "data") {
 
     // Bounds checks: run on curr alone (don't require prev to be non-null)
     if (curr.renewable_share !== null) {
-      if (curr.renewable_share < 0 || curr.renewable_share > 100) {
+      if (curr.renewable_share < 0 || curr.renewable_share > 200) {
+        // Values < 0 or > 200 are clearly API errors
         const ts = new Date(curr.start_timestamp).toISOString();
-        critical.push(`Renewable share out of range [0,100]: ${curr.renewable_share.toFixed(1)}% at ${ts}`);
+        critical.push(`Renewable share out of range [0,200]: ${curr.renewable_share.toFixed(1)}% at ${ts}`);
+      } else if (curr.renewable_share > 100) {
+        // Values 100-200% are physically possible (renewable overproduction / net export)
+        const ts = new Date(curr.start_timestamp).toISOString();
+        warnings.push(`Renewable share above 100% (overproduction): ${curr.renewable_share.toFixed(1)}% at ${ts}`);
       }
     }
     if (curr.marketprice !== null && typeof curr.marketprice === "number" && isFinite(curr.marketprice)) {


### PR DESCRIPTION
## Problem

Der Fetch-Workflow schlägt seit heute Nachmittag (17:46, 19:27, 21:00, 21:07 UTC) fehl. `fetch.yml` checkt immer `ref: main` aus und führt dort `scripts/merge-market-data.js` aus. Die Energy Charts API liefert für den 4. Juni Erneuerbare-Anteil-Werte von 101–120%, was das Script als kritischen Fehler wertet und abbricht:

```
❌ CRITICAL data quality errors in energy-charts (33):
   Renewable share out of range [0,100]: 101.2% at 2026-06-04T06:45:00.000Z
   ...
❌ Aborting: physically impossible values detected.
```

## Ursache

Werte >100% sind **physikalisch korrekt**: Bei Solar/Wind-Überproduktion (z.B. sonnige Sommertage) übersteigt die Erzeugung den nationalen Bedarf – der Überschuss wird exportiert. Energy Charts meldet das als Anteil >100%. Die Grenze `> 100` war zu eng.

## Fix (`scripts/merge-market-data.js`, 5 Zeilen)

| Bereich | Vorher | Nachher |
|---|---|---|
| 0–100% | ✅ ok | ✅ ok |
| 100–200% | ❌ kritischer Fehler (Abbruch) | ⚠️ Warnung (Pipeline läuft weiter) |
| < 0 oder > 200% | ❌ kritischer Fehler | ❌ kritischer Fehler |

Echte API-Fehler (NaN, > 200%) werden weiterhin blockiert.

**Direkt nach `main`**, weil `fetch.yml` explizit `ref: main` auscheckt.

## Test plan
- [ ] Fetch-Workflow manuell triggern → Workflow läuft durch
- [ ] Log zeigt Warnings für Overproduction-Werte statt Abbruch
- [ ] `marketdata.json` wird aktualisiert

https://claude.ai/code/session_014Z8emErZEA792VpwHfkLt2

---
_Generated by [Claude Code](https://claude.ai/code/session_014Z8emErZEA792VpwHfkLt2)_