### PR TITLE
feat: Claude PR-Review als Merge-Gate aktivieren

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   pull-requests: write
   contents: read
+  statuses: write
 
 jobs:
   pr-review:

--- a/.github/workflows/review-gate-resolve.yml
+++ b/.github/workflows/review-gate-resolve.yml
@@ -1,0 +1,17 @@
+name: Review Gate Resolve
+
+# Setzt den Commit-Status "review-gate" je nachdem, ob das Quittierungs-Label
+# gesetzt ist. Reagiert auf labeled/unlabeled, damit das Gate sofort umspringt,
+# ohne neuen Commit. Siehe reusable-pr-review.yml (Gate-Erzeugung).
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+
+permissions:
+  statuses: write
+  pull-requests: read
+
+jobs:
+  resolve:
+    uses: S540d/project-templates/.github/workflows/reusable-review-gate-resolve.yml@v1


### PR DESCRIPTION
## Was & Warum

Aktiviert das neue **review-gate** (aus project-templates@v1) in diesem Repo. Bisher war der Claude-Review nur ein Kommentar ohne Merge-Wirkung — bei #324 wurden Findings ungelesen gemerged.

## Änderungen
- `pr-review.yml`: `statuses: write` ergänzt (für Commit-Status `review-gate`).
- `review-gate-resolve.yml` (neu): Label `suggestions gelesen und verstanden` → `review-gate` grün; entfernen → rot. Trigger `labeled/unlabeled`.
- Label `suggestions gelesen und verstanden` im Repo angelegt.

## Selbsttest

Dieser PR ist zugleich der erste Live-Test des Gates:
- Claude sollte einen Review-Kommentar posten + Commit-Status `review-gate` setzen.
- Bei Findings: rot → Label setzen → grün.

Nach erfolgreicher Verifikation wird `review-gate` als required status check ins `protect-main`-Ruleset aufgenommen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)