### PR TITLE
ci: pr-review.yml contents write→read + permission allowlist

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__github__pull_request_read",
+      "mcp__github__actions_list",
+      "mcp__github__get_job_logs"
+    ]
+  }
+}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   pull-requests: write
-  contents: write
+  contents: read
   statuses: write
 
 jobs:


### PR DESCRIPTION
## Was

- `pr-review.yml`: `contents: write` → `contents: read` — der Review-Job pusht keine Commits mehr, write war zu weit gefasst
- `.claude/settings.json`: Permission-Allowlist für häufig genutzte read-only GitHub-MCP-Tools (reduziert Prompt-Popups)

## Warum

`fix/pr-333-review-findings` und `claude/fetch-workflow-issue-duLln` hatten diese Fixes – sie waren nicht in testing gemergt. Stale Branches werden nach diesem Merge gelöscht.