### PR TITLE
docs: Merge-Gate-Abschnitt auf einstufigen Review aktualisieren

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,12 +58,13 @@ gh pr create --base testing --title "..." --body "..."
 - At least one code review (if available)
 
 ### Automated Claude PR Review (Merge-Gate)
-PRs gegen `testing` und `main` lösen automatisch einen zweistufigen Claude-Review aus:
+PRs gegen `testing` und `main` lösen automatisch einen einstufigen Claude-Review aus
+(`reusable-pr-review.yml@v1`, nur Review – der frühere Autofix-Job wurde entfernt):
 
-1. **Autofix:** Ein Claude-Agent fixt alle umsetzbaren Findings selbst (Commit `[auto]` + Push auf den PR-Branch).
-2. **Review:** Bewertet den korrigierten End-Stand und setzt den required Status-Check **`review-gate`** sowie ein Label:
-   - Keine offenen Findings → 🟢 `ready to merge` → Merge frei
-   - Findings übrig → 🔴 `needs human review` + Inline-Kommentare
+- **Review:** Bewertet den PR-Diff und setzt den required Status-Check **`review-gate`** sowie ein Label:
+  - Keine offenen Findings → 🟢 `ready to merge` → Merge frei
+  - Findings übrig → 🔴 `needs human review` + Inline-Kommentare
+  - Kein `ANTHROPIC_API_KEY` gesetzt → Review übersprungen, Gate bleibt grün (Repo mergebar)
 
 Bei `needs human review`:
 1. Review-Kommentar und Inline-Findings lesen


### PR DESCRIPTION
## Was

CLAUDE.md beschrieb den Merge-Gate noch als zweistufig (Autofix + Review) mit `[auto]`-Commits. Der Autofix-Job wurde aber in project-templates #57 entfernt — der Review läuft nur noch einstufig über `reusable-pr-review.yml@v1`.

## Änderung

- Abschnitt 'Automated Claude PR Review' auf einstufige Logik korrigiert
- Fall 'kein ANTHROPIC_API_KEY → Gate grün' ergänzt

## Nebeneffekt

Dient zugleich als Verifikation, dass der `review-gate` nach der temporären API-Key-Deaktivierung wieder grün durchläuft.