### PR TITLE
security(web): unnötiges jsdelivr aus CSP entfernen + Referrer-Policy ergänzen

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,10 @@
     <meta name="description" content="Visualisierung von Energiepreisen und erneuerbaren Energien in Deutschland" />
 
     <!-- Content Security Policy: Prevent XSS and injection attacks -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://s540d.github.io https://energypricegermany.sven4321.workers.dev https://energy-charts.info https://www.awattar.de; manifest-src 'self';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://s540d.github.io https://energypricegermany.sven4321.workers.dev https://energy-charts.info https://www.awattar.de; manifest-src 'self';" />
+
+    <!-- Referrer-Policy: avoid leaking the full URL to cross-origin requests -->
+    <meta name="referrer" content="strict-origin-when-cross-origin" />
 
     <link rel="manifest" href="/manifest.json" />
     <meta name="theme-color" content="#6200EE" />


### PR DESCRIPTION
## Kontext

Ausgelöst durch eine Untersuchung des gemeldeten Link-Problems (Freunde konnten `https://s540d.github.io/Energy_Price_Germany/` nicht öffnen). Ergebnis dieser Untersuchung: **Die Seite ist gesund** (HTTP 200, gültiges Zertifikat, Bundle lädt) — die Fehler der Freunde (Firefox-HSTS-Bruch + Safari-Timeout) sind reine **Netzwerk-/VPN-Probleme auf deren Seite**, kein App-Defekt.

Dieser PR ist ein **unabhängiges, optionales Härten** der Security-Header, das bei der Untersuchung als sinnvoll auffiel.

## Was ändert sich

In `public/index.html` (= Expo-Web-Template):

1. **`https://cdn.jsdelivr.net` aus `script-src` entfernt** — war erlaubt, wird aber nirgends im ausgelieferten HTML referenziert (`grep` über Live-Seite leer). Unnötige Angriffsfläche.
2. **`Referrer-Policy` ergänzt** (`strict-origin-when-cross-origin`) — verhindert, dass bei Cross-Origin-Requests die volle URL geleakt wird.

`'unsafe-inline'`/`'unsafe-eval'` bleiben bewusst drin — von der Expo/Metro-Web-Runtime benötigt.

## Verifikation

`public/index.html` wird von Expo beim `expo export --platform web` als Template herangezogen (post-build.js kopiert es bewusst NICHT selbst). Lokal gebaut und geprüft:

- `dist/index.html`: jsdelivr-Vorkommen = **0** ✅
- `dist/index.html`: `name="referrer"` = **1** ✅
- Pre-commit & pre-push Hooks (inkl. Prettier, Security-Scan) grün ✅

## Hinweis

GitHub Pages erlaubt keine eigenen HTTP-Response-Header — CSP/Referrer-Policy sind daher nur via Meta-Tag im HTML möglich. HSTS kommt von GitHub selbst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)