### PR TITLE
chore: aufräumen-Skill – Auto-Marktdaten aus Divergenz-Check filtern

### DIFF
--- a/.claude/commands/aufräumen.md
+++ b/.claude/commands/aufräumen.md
@@ -2,6 +2,46 @@
 
 Führe den täglichen Cleanup-Workflow durch:
 
+## 0. Branch-Übersicht: testing vs. main (alle Repos)
+
+Erstelle zu Beginn eine Tabelle aller Repositories mit dem Stand von `testing` gegenüber `main`:
+
+```bash
+for repo in Eisenhauer 1x1_Trainer DrawFromMemory EnergyPriceGermany Pflanzkalender safe_my_plants CD-to-Spotify-PWA project-templates; do
+  dir="/Users/svenstrohkark/Documents/Programmierung/Projects/$repo"
+  if [ -d "$dir/.git" ]; then
+    cd "$dir"
+    git fetch --all --prune -q 2>/dev/null
+    ab=$(git rev-list --left-right --count origin/main...origin/testing 2>/dev/null)
+    main_ahead=$(echo $ab | awk '{print $1}')
+    test_ahead=$(echo $ab | awk '{print $2}')
+    # Phantom-Divergenz ausblenden: nur Nicht-Auto-Commits auf main zählen.
+    # Auto-Commits = extern gezogene Marktdaten o.ä. (marketdata.json, energy-charts,
+    # plant data, "[skip ci]", "chore(data)"). Diese landen per Workflow direkt auf main
+    # und erzeugen sonst Dauer-Divergenz, obwohl inhaltlich nichts auseinanderläuft.
+    real_main_ahead=$(git log --oneline origin/testing..origin/main 2>/dev/null \
+      | grep -vicE 'update marketdata|energy-charts|chore\(data\)|\[skip ci\]|auto-update' )
+    echo "$repo | testing +$test_ahead | main +$main_ahead (echt: $real_main_ahead)"
+  fi
+done
+```
+
+Zeige das Ergebnis als Markdown-Tabelle:
+
+| Projekt | testing ahead | main ahead (echt) | Status |
+|---|---|---|---|
+| ... | ... | ... | ✅ OK / 🔴 Sync-PR nötig |
+
+**Statusregeln (auf `real_main_ahead` basieren, NICHT auf `main_ahead`):**
+- ✅ OK — `real_main_ahead = 0` (egal wie viele Auto-Marktdaten-Commits auf main liegen —
+  diese sind erwartet und kein Grund für einen Sync-PR)
+- 🔴 Sync-PR nötig — `real_main_ahead > 0` (echte, nicht-automatische Commits liegen nur auf
+  main und fehlen in testing → `sync: main → testing` PR erstellen)
+
+> **Warum:** Workflows committen extern gezogene Daten (z.B. `marketdata.json`) direkt auf
+> `main`. Ohne Filter meldet der Check Dauer-Divergenz, obwohl nichts Echtes auseinanderläuft.
+> Maßgeblich ist deshalb `real_main_ahead`.
+
 ## 1. Repository Status prüfen
 - Prüfe `git status` für uncommitted changes
 - Liste alle lokalen Branches


### PR DESCRIPTION
## Problem

Der Aufräum-Skill (Abschnitt 0, Branch-Übersicht) meldete für EnergyPriceGermany immer wieder eine Divergenz `main +N`, obwohl inhaltlich nichts auseinanderläuft. Ursache: Der `fetch`-Workflow committet extern gezogene Marktdaten (`marketdata.json`) **direkt auf `main`**, alle ~2h. Diese Auto-Commits erzeugen Phantom-Divergenz.

## Lösung (Option B)

Abschnitt 0 berechnet jetzt zusätzlich `real_main_ahead` — main-Commits **ohne** Auto-Marktdaten (grep-Filter auf `update marketdata|energy-charts|chore(data)|[skip ci]|auto-update`). Die Statusregeln stützen sich darauf:

- ✅ OK — `real_main_ahead = 0` (egal wie viele Daten-Commits auf main liegen)
- 🔴 Sync-PR nötig — `real_main_ahead > 0` (echte, nicht-automatische Commits nur auf main)

## Verifiziert (live über alle 8 Repos)

| Repo | main +N | echt | Status alt → neu |
|---|---|---|---|
| EnergyPriceGermany | +15 | **0** | 🔴 → ✅ |
| Eisenhauer / 1x1_Trainer | +0 | 0 | ✅ |
| DrawFromMemory/Pflanzkalender/safe_my_plants/CD-to-Spotify/project-templates | ≥1 | ≥1 | 🔴 (echte Commits, korrekt) |

Der Filter unterdrückt also nur Phantom-Divergenz; echte Sync-Bedarfe bleiben sichtbar.

> Hinweis: Diese Änderung betrifft nur die EPG-Kopie des Skills. Übertragung auf die Master-Quelle (`project-templates/claude-commands/aufräumen.md`) und die anderen Repos kann separat erfolgen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)