### PR TITLE
feat(#356): Länder-Umschalter – Niederlande (nationale Daten, ohne PLZ)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -18,6 +18,7 @@ import { getThemeColors } from './utils/theme';
 import { useEnergyData } from './hooks/useEnergyData';
 import { useLanguageContext } from './context/LanguageContext';
 import { useSettingsContext } from './context/SettingsContext';
+import { useCountryContext } from './context/CountryContext';
 import { checkPriceAlert } from './utils/priceAlertUtils';
 import { usePriceAlertNotification } from './hooks/usePriceAlertNotification';
 import { ChartSkeleton } from './components/ui/ChartSkeleton';
@@ -87,7 +88,8 @@ function AppContent() {
     historyCacheLimitMb,
   } = useSettingsContext();
   const { language, t } = useLanguageContext();
-  const { energyData, loading } = useEnergyData(debouncedPostalCode);
+  const { country, countryConfig } = useCountryContext();
+  const { energyData, loading } = useEnergyData(debouncedPostalCode, country);
 
   // Nutzer-Limit für die persistente Historie an den Daten-Manager weitergeben (#307)
   useEffect(() => {
@@ -125,10 +127,11 @@ function AppContent() {
 
   const hasRegionalData = useMemo(
     () =>
+      countryConfig.hasRegionalData &&
       filteredEnergyData.some(
         item => item.renewableShareRegional !== null && item.renewableShareRegional !== undefined
       ),
-    [filteredEnergyData]
+    [filteredEnergyData, countryConfig.hasRegionalData]
   );
 
   const metrics = useMemo(() => calculateMetrics(filteredEnergyData), [filteredEnergyData]);
@@ -294,6 +297,7 @@ function AppContent() {
           livePulseStyle={livePulseStyle}
           alertLowLabel={t.priceAlertActiveLow}
           alertHighLabel={t.priceAlertActiveHigh}
+          countryName={t[countryConfig.translationKey]}
           onOpenCalculator={() => setCalculatorVisible(true)}
           onOpenSettings={() => setMenuVisible(true)}
         />
@@ -393,14 +397,17 @@ const styles = StyleSheet.create({
 
 import { SettingsProvider } from './context/SettingsContext';
 import { LanguageProvider } from './context/LanguageContext';
+import { CountryProvider } from './context/CountryContext';
 
 export default function App() {
   return (
     <SafeAreaProvider style={{ flex: 1 }}>
       <LanguageProvider>
-        <SettingsProvider>
-          <AppContent />
-        </SettingsProvider>
+        <CountryProvider>
+          <SettingsProvider>
+            <AppContent />
+          </SettingsProvider>
+        </CountryProvider>
       </LanguageProvider>
     </SafeAreaProvider>
   );

--- a/app.test.tsx
+++ b/app.test.tsx
@@ -171,7 +171,7 @@ describe('App', () => {
       renderWithProviders(<App />);
 
       await waitFor(() => {
-        expect(mockFetchEnergyData).toHaveBeenCalledWith(undefined);
+        expect(mockFetchEnergyData).toHaveBeenCalledWith('de', undefined);
       });
     });
 
@@ -593,7 +593,7 @@ describe('App', () => {
       renderWithProviders(<App />);
 
       await waitFor(() => {
-        expect(mockFetchEnergyData).toHaveBeenCalledWith(undefined);
+        expect(mockFetchEnergyData).toHaveBeenCalledWith('de', undefined);
       });
     });
   });

--- a/components/AppHeader.tsx
+++ b/components/AppHeader.tsx
@@ -14,6 +14,7 @@ type Props = {
   livePulseStyle: AnimatedStyle;
   alertLowLabel: string;
   alertHighLabel: string;
+  countryName: string;
   onOpenCalculator: () => void;
   onOpenSettings: () => void;
 };
@@ -26,6 +27,7 @@ export function AppHeader({
   livePulseStyle,
   alertLowLabel,
   alertHighLabel,
+  countryName,
   onOpenCalculator,
   onOpenSettings,
 }: Props) {
@@ -59,7 +61,7 @@ export function AppHeader({
           </Text>
         </View>
         <Text style={[styles.titleLine1, { color: colors.text }]}>Energy Price</Text>
-        <Text style={[styles.titleLine2, { color: colors.accentGreen }]}>Germany</Text>
+        <Text style={[styles.titleLine2, { color: colors.accentGreen }]}>{countryName}</Text>
       </View>
 
       <View style={styles.buttons}>

--- a/components/customize/CountrySection.tsx
+++ b/components/customize/CountrySection.tsx
@@ -1,0 +1,87 @@
+import React, { useMemo } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, useColorScheme } from 'react-native';
+import { useLanguageContext } from '../../context/LanguageContext';
+import { useCountryContext } from '../../context/CountryContext';
+import { getThemeColors } from '../../utils/theme';
+import { useSettingsContext } from '../../context/SettingsContext';
+import { COUNTRIES, COUNTRY_CODES } from '../../utils/countries';
+
+/**
+ * Country selection section for the Customize menu.
+ * Switches the active country (national data only). Determines data
+ * availability and whether the regional/PLZ UI is shown (Issue #356).
+ */
+export function CountrySection() {
+  const { t } = useLanguageContext();
+  const { country, setCountry } = useCountryContext();
+  const { theme } = useSettingsContext();
+  const systemTheme = useColorScheme();
+  const colors = useMemo(() => getThemeColors(theme, systemTheme || 'light'), [theme, systemTheme]);
+
+  return (
+    <View style={styles.menuSection}>
+      <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>{t.country}</Text>
+      <View style={styles.countryToggle}>
+        {COUNTRY_CODES.map(code => {
+          const config = COUNTRIES[code];
+          const active = country === code;
+          return (
+            <TouchableOpacity
+              key={code}
+              style={[
+                styles.countryButton,
+                active && styles.countryButtonActive,
+                { backgroundColor: active ? colors.primary : colors.gridLine },
+              ]}
+              onPress={() => setCountry(code)}
+              accessibilityRole="button"
+              accessibilityState={{ selected: active }}
+            >
+              <Text
+                style={{
+                  color: active ? '#fff' : colors.text,
+                  fontSize: 12,
+                  fontWeight: '600',
+                }}
+              >
+                {config.flag} {t[config.translationKey]}
+                {config.beta ? ` ${t.countryBeta}` : ''}
+              </Text>
+            </TouchableOpacity>
+          );
+        })}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  menuSection: {
+    gap: 12,
+  },
+  sectionTitle: {
+    fontSize: 11,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  countryToggle: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  countryButton: {
+    flex: 1,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  countryButtonActive: {
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.1,
+    shadowRadius: 4,
+    elevation: 2,
+  },
+});

--- a/components/customize/CustomizeModal.tsx
+++ b/components/customize/CustomizeModal.tsx
@@ -10,9 +10,11 @@ import {
   Dimensions,
 } from 'react-native';
 import { useLanguageContext } from '../../context/LanguageContext';
+import { useCountryContext } from '../../context/CountryContext';
 import { getThemeColors } from '../../utils/theme';
 import { useSettingsContext } from '../../context/SettingsContext';
 import { LanguageSection } from '../settings/LanguageSection';
+import { CountrySection } from './CountrySection';
 import { PostalCodeSection } from './PostalCodeSection';
 import { GridFeesSection } from './GridFeesSection';
 import { PriceDisplayModeSection } from './PriceDisplayModeSection';
@@ -30,9 +32,13 @@ interface CustomizeModalProps {
  */
 export function CustomizeModal({ visible, onClose }: CustomizeModalProps) {
   const { t } = useLanguageContext();
+  const { countryConfig } = useCountryContext();
   const { theme } = useSettingsContext();
   const systemTheme = useColorScheme();
   const colors = useMemo(() => getThemeColors(theme, systemTheme || 'light'), [theme, systemTheme]);
+
+  // Postal-code / regional UI only applies to countries with regional data (DE).
+  const showRegionalInput = countryConfig.hasRegionalData;
 
   if (!visible) return null;
 
@@ -53,20 +59,29 @@ export function CustomizeModal({ visible, onClose }: CustomizeModalProps) {
 
         {/* Scrollable Content */}
         <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollViewContent}>
+          {/* Country Section (#356) */}
+          <CountrySection />
+
+          <View style={[styles.separator, { backgroundColor: colors.gridLine }]} />
+
           {/* Language Section */}
           <LanguageSection />
 
           <View style={[styles.separator, { backgroundColor: colors.gridLine }]} />
 
-          {/* Postal Code + Grid Fees in one row */}
-          <View style={styles.inlineRow}>
-            <View style={styles.inlineItem}>
-              <PostalCodeSection />
+          {/* Postal Code + Grid Fees in one row (PLZ only for regional countries) */}
+          {showRegionalInput ? (
+            <View style={styles.inlineRow}>
+              <View style={styles.inlineItem}>
+                <PostalCodeSection />
+              </View>
+              <View style={styles.inlineItem}>
+                <GridFeesSection />
+              </View>
             </View>
-            <View style={styles.inlineItem}>
-              <GridFeesSection />
-            </View>
-          </View>
+          ) : (
+            <GridFeesSection />
+          )}
 
           <View style={[styles.separator, { backgroundColor: colors.gridLine }]} />
 

--- a/components/customize/__tests__/CustomizeModal.test.tsx
+++ b/components/customize/__tests__/CustomizeModal.test.tsx
@@ -8,6 +8,7 @@ import { render, waitFor } from '@testing-library/react-native';
 import { CustomizeModal } from '../CustomizeModal';
 import { LanguageProvider } from '../../../context/LanguageContext';
 import { SettingsProvider } from '../../../context/SettingsContext';
+import { CountryProvider } from '../../../context/CountryContext';
 
 // Mock theme utilities
 jest.mock('../../../utils/theme', () => ({
@@ -33,9 +34,11 @@ jest.mock('../../settings/BetaModeSection', () => ({
 
 // Wrapper component with required contexts
 const TestWrapper = ({ children }: { children: React.ReactNode }) => (
-  <SettingsProvider>
-    <LanguageProvider>{children}</LanguageProvider>
-  </SettingsProvider>
+  <CountryProvider>
+    <SettingsProvider>
+      <LanguageProvider>{children}</LanguageProvider>
+    </SettingsProvider>
+  </CountryProvider>
 );
 
 describe('CustomizeModal', () => {

--- a/context/CountryContext.tsx
+++ b/context/CountryContext.tsx
@@ -1,0 +1,47 @@
+import type { ReactNode } from 'react';
+import React, { createContext, useContext } from 'react';
+import { useCountry } from '../hooks/useCountry';
+import type { CountryCode, CountryConfig } from '../utils/countries';
+import { COUNTRIES } from '../utils/countries';
+
+interface CountryContextValue {
+  country: CountryCode;
+  setCountry: (country: CountryCode) => void;
+  /** Resolved config for the active country. */
+  countryConfig: CountryConfig;
+}
+
+const CountryContext = createContext<CountryContextValue | undefined>(undefined);
+
+/**
+ * Provider for the active country.
+ * Wraps the app so the selected country is available everywhere via
+ * useCountryContext. Independent from language (see CLAUDE.md / Issue #356).
+ */
+export function CountryProvider({ children }: { children: ReactNode }) {
+  const [country, setCountry] = useCountry();
+
+  return (
+    <CountryContext.Provider
+      value={{
+        country,
+        setCountry,
+        countryConfig: COUNTRIES[country],
+      }}
+    >
+      {children}
+    </CountryContext.Provider>
+  );
+}
+
+/**
+ * Hook to access the country context.
+ * Must be used within CountryProvider.
+ */
+export function useCountryContext(): CountryContextValue {
+  const context = useContext(CountryContext);
+  if (!context) {
+    throw new Error('useCountryContext must be used within CountryProvider');
+  }
+  return context;
+}

--- a/hooks/useCountry.ts
+++ b/hooks/useCountry.ts
@@ -1,0 +1,54 @@
+import { useState, useEffect, useRef } from 'react';
+import { usePersistence } from './usePersistence';
+import type { CountryCode } from '../utils/countries';
+import { DEFAULT_COUNTRY, isCountryCode } from '../utils/countries';
+
+const STORAGE_KEY = 'country';
+
+/**
+ * Hook for managing the active country with persistence.
+ * Loads from storage on mount, defaults to {@link DEFAULT_COUNTRY}, and
+ * automatically saves changes. Country is independent from the UI language
+ * (a user may view NL data with the German UI).
+ */
+export function useCountry(): [CountryCode, (country: CountryCode) => void] {
+  const [country, setCountryState] = useState<CountryCode>(DEFAULT_COUNTRY);
+  const [isInitialized, setIsInitialized] = useState(false);
+  const { getItem, setItem } = usePersistence();
+  const initRef = useRef(false);
+
+  // Load country on mount
+  useEffect(() => {
+    if (initRef.current) return;
+    initRef.current = true;
+
+    async function loadCountry() {
+      try {
+        const saved = await getItem(STORAGE_KEY);
+        if (isCountryCode(saved)) {
+          setCountryState(saved);
+        }
+      } catch (error) {
+      } finally {
+        setIsInitialized(true);
+      }
+    }
+
+    loadCountry();
+  }, [getItem]);
+
+  // Save country when it changes (after initialization)
+  useEffect(() => {
+    if (!isInitialized) return;
+
+    async function saveCountry() {
+      try {
+        await setItem(STORAGE_KEY, country);
+      } catch (error) {}
+    }
+
+    saveCountry();
+  }, [country, isInitialized, setItem]);
+
+  return [country, setCountryState];
+}

--- a/hooks/useEnergyData.ts
+++ b/hooks/useEnergyData.ts
@@ -1,13 +1,15 @@
 import { useState, useEffect, useRef } from 'react';
 import { fetchEnergyData, energyDataManager } from '../services/energyDataManager';
 import type { EnergyData } from '../utils/metrics';
+import type { CountryCode } from '../utils/countries';
+import { DEFAULT_COUNTRY } from '../utils/countries';
 
 /**
  * Hook for fetching and managing energy data
  * Handles loading states and errors
- * Invalidates cache when postal code changes
+ * Invalidates cache when postal code or country changes
  */
-export function useEnergyData(debouncedPostalCode: string) {
+export function useEnergyData(debouncedPostalCode: string, country: CountryCode = DEFAULT_COUNTRY) {
   const [energyData, setEnergyData] = useState<EnergyData[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -19,16 +21,16 @@ export function useEnergyData(debouncedPostalCode: string) {
         setLoading(true);
         setError(null);
 
-        // Invalidate cache on postal code change (but not on first mount)
+        // Invalidate the regional cache on postal code / country change (but
+        // not on first mount). The national cache is keyed by country inside
+        // the data manager, so switching country reloads it automatically.
         if (!isInitialMountRef.current) {
-          // Performance: Only invalidate regional cache on postal code change
-          // National cache is still valid unless the API data updates
           await energyDataManager.invalidateRegionalCache();
         } else {
           isInitialMountRef.current = false;
         }
 
-        const data = await fetchEnergyData(debouncedPostalCode || undefined);
+        const data = await fetchEnergyData(country, debouncedPostalCode || undefined);
         setEnergyData(data);
       } catch (err) {
         setError(err instanceof Error ? err : new Error('Unknown error loading energy data'));
@@ -39,7 +41,7 @@ export function useEnergyData(debouncedPostalCode: string) {
     }
 
     loadData();
-  }, [debouncedPostalCode]);
+  }, [debouncedPostalCode, country]);
 
   return { energyData, loading, error };
 }

--- a/services/energyDataManager.test.ts
+++ b/services/energyDataManager.test.ts
@@ -161,7 +161,7 @@ describe('EnergyDataManager', () => {
         json: async () => mockRegionalDataResponse,
       } as Response);
 
-      const data = await manager.loadEnergyData('12345');
+      const data = await manager.loadEnergyData('de', '12345');
 
       expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(data.length).toBeGreaterThan(0);
@@ -190,7 +190,7 @@ describe('EnergyDataManager', () => {
         json: async () => mockMarketDataResponse,
       } as Response);
 
-      const data = await manager.loadEnergyData('12345');
+      const data = await manager.loadEnergyData('de', '12345');
 
       // Should only fetch national data (1 call), not regional (uses cache)
       expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -223,7 +223,7 @@ describe('EnergyDataManager', () => {
         json: async () => mockRegionalDataResponse,
       } as Response);
 
-      await manager.loadEnergyData('12345');
+      await manager.loadEnergyData('de', '12345');
 
       // Should fetch both national AND regional (2 calls)
       expect(mockFetch).toHaveBeenCalledTimes(2);
@@ -279,7 +279,7 @@ describe('EnergyDataManager', () => {
       // Mock failed regional data fetch
       mockFetch.mockRejectedValueOnce(new Error('Regional API error'));
 
-      const data = await manager.loadEnergyData('12345');
+      const data = await manager.loadEnergyData('de', '12345');
 
       // Should still return national data
       expect(data.length).toBeGreaterThan(0);
@@ -302,7 +302,7 @@ describe('EnergyDataManager', () => {
         json: async () => mockRegionalDataResponse,
       } as Response);
 
-      const data = await manager.loadEnergyData('12345');
+      const data = await manager.loadEnergyData('de', '12345');
 
       // Should still work, just without cached data
       expect(data.length).toBeGreaterThan(0);
@@ -323,7 +323,7 @@ describe('EnergyDataManager', () => {
         json: async () => mockRegionalDataResponse,
       } as Response);
 
-      const data = await manager.loadEnergyData('12345');
+      const data = await manager.loadEnergyData('de', '12345');
 
       // Should still return data even if caching fails
       expect(data.length).toBeGreaterThan(0);
@@ -360,7 +360,7 @@ describe('EnergyDataManager', () => {
         json: async () => mockRegionalDataResponse,
       } as Response);
 
-      await manager.loadEnergyData('12345');
+      await manager.loadEnergyData('de', '12345');
 
       // Invalidate regional cache
       await manager.invalidateRegionalCache();

--- a/services/energyDataManager.ts
+++ b/services/energyDataManager.ts
@@ -5,6 +5,8 @@ import { validateMarketDataResponse, fetchWithTimeout } from '../utils/apiValida
 import { RegionalDataCache } from './regionalDataCache';
 import { mergeRegionalData } from './dataMerger';
 import { historicalDataStore } from './historicalDataStore';
+import type { CountryCode } from '../utils/countries';
+import { COUNTRIES, DEFAULT_COUNTRY } from '../utils/countries';
 
 /**
  * Datenquelle-Typen
@@ -43,6 +45,8 @@ export class EnergyDataManager {
   private static instance: EnergyDataManager;
   private cachedData: EnergyData[] | null = null;
   private cacheTimestamp: number = 0;
+  // Country the cached data belongs to – switching country invalidates the cache.
+  private dataCountry: CountryCode | null = null;
   private currentDataSource: DataSource = 'none';
   private isLoading: boolean = false;
   private loadingPromise: Promise<EnergyData[]> | null = null;
@@ -92,15 +96,18 @@ export class EnergyDataManager {
    * Lädt Rohdaten von der API
    * Includes timeout protection and response validation
    */
-  private async fetchRawData(): Promise<MarketDataResponse> {
+  private async fetchRawData(country: CountryCode): Promise<MarketDataResponse> {
     // Cache-busting Parameter
     const cacheBust = Date.now();
+
+    // Country-specific data path (Germany stays on legacy flat path).
+    const dataPath = COUNTRIES[country].marketDataPath;
 
     // For native apps, use full URL; for web, use relative path
     const dataUrl =
       Platform.OS === 'web'
-        ? `./data/marketdata.json?v=${cacheBust}`
-        : `https://s540d.github.io/Energy_Price_Germany/data/marketdata.json?v=${cacheBust}`;
+        ? `./${dataPath}?v=${cacheBust}`
+        : `https://s540d.github.io/Energy_Price_Germany/${dataPath}?v=${cacheBust}`;
 
     const response = await fetchWithTimeout(dataUrl, {}, 10000);
 
@@ -161,18 +168,24 @@ export class EnergyDataManager {
   /**
    * Lädt und verarbeitet Energiedaten
    * Verwendet Cache wenn verfügbar und gültig
-   * @param postalCode Optional postal code for regional data
+   * @param country Active country (determines data source + regional availability)
+   * @param postalCode Optional postal code for regional data (DE only)
    */
-  public async loadEnergyData(postalCode?: string): Promise<EnergyData[]> {
+  public async loadEnergyData(
+    country: CountryCode = DEFAULT_COUNTRY,
+    postalCode?: string
+  ): Promise<EnergyData[]> {
     // Wenn bereits ein Ladevorgang läuft, warte darauf
     if (this.isLoading && this.loadingPromise) {
       return this.loadingPromise;
     }
 
-    // Prüfe Cache
-    if (this.isCacheValid()) {
-      // If postal code is provided, merge regional data
-      if (isValidPostalCode(postalCode) && postalCode) {
+    const regionalEnabled = COUNTRIES[country].hasRegionalData;
+
+    // Prüfe Cache – nur gültig, wenn er zum selben Land gehört
+    if (this.dataCountry === country && this.isCacheValid()) {
+      // If postal code is provided (regional countries only), merge regional data
+      if (regionalEnabled && isValidPostalCode(postalCode) && postalCode) {
         const regionalData = await this.regionalCache.fetchRegionalData(postalCode);
         if (regionalData && this.cachedData) {
           return mergeRegionalData(this.cachedData, regionalData);
@@ -184,7 +197,7 @@ export class EnergyDataManager {
 
     // Starte Ladevorgang
     this.isLoading = true;
-    this.loadingPromise = this.performDataLoad(postalCode);
+    this.loadingPromise = this.performDataLoad(country, postalCode);
 
     try {
       const data = await this.loadingPromise;
@@ -198,24 +211,31 @@ export class EnergyDataManager {
   /**
    * Führt den eigentlichen Datenlade-Vorgang aus
    */
-  private async performDataLoad(postalCode?: string): Promise<EnergyData[]> {
+  private async performDataLoad(country: CountryCode, postalCode?: string): Promise<EnergyData[]> {
+    const regionalEnabled = COUNTRIES[country].hasRegionalData;
     try {
-      const rawData = await this.fetchRawData();
+      const rawData = await this.fetchRawData(country);
       let processedData = this.processRawData(rawData);
 
       // Cache die verarbeiteten Daten
       this.cachedData = processedData;
       this.cacheTimestamp = Date.now();
+      this.dataCountry = country;
 
       // Persistente Historie aktualisieren (fire-and-forget, nationale Daten) – #307.
       // Per Microtask verzögert, damit das Snapshotting nicht mit den
       // Storage-Lesezugriffen des Regional-Caches im selben Tick verschachtelt.
-      Promise.resolve()
-        .then(() => historicalDataStore.recordSnapshot(processedData, this.historyLimitBytes))
-        .catch(() => {});
+      // Hinweis (#356): Der Historien-Store ist noch nicht länder-namespaced
+      // (Folge-Schritt), daher wird vorerst nur für das Default-Land (DE)
+      // ein Snapshot aufgezeichnet, um die DE-Historie nicht zu vermischen.
+      if (country === DEFAULT_COUNTRY) {
+        Promise.resolve()
+          .then(() => historicalDataStore.recordSnapshot(processedData, this.historyLimitBytes))
+          .catch(() => {});
+      }
 
-      // If postal code is provided, fetch and merge regional data
-      if (isValidPostalCode(postalCode) && postalCode) {
+      // If postal code is provided (regional countries only), fetch + merge regional data
+      if (regionalEnabled && isValidPostalCode(postalCode) && postalCode) {
         const regionalData = await this.regionalCache.fetchRegionalData(postalCode);
         if (regionalData) {
           processedData = mergeRegionalData(processedData, regionalData);
@@ -228,6 +248,7 @@ export class EnergyDataManager {
       const mockData = this.generateMockData();
       this.cachedData = mockData;
       this.cacheTimestamp = Date.now();
+      this.dataCountry = country;
 
       return mockData;
     }
@@ -247,6 +268,7 @@ export class EnergyDataManager {
   public invalidateCache(): void {
     this.cachedData = null;
     this.cacheTimestamp = 0;
+    this.dataCountry = null;
     this.currentDataSource = 'none';
   }
 
@@ -277,8 +299,11 @@ export class EnergyDataManager {
 export const energyDataManager = EnergyDataManager.getInstance();
 
 // Legacy-Funktionen für Abwärtskompatibilität
-export async function fetchEnergyData(postalCode?: string): Promise<EnergyData[]> {
-  return energyDataManager.loadEnergyData(postalCode);
+export async function fetchEnergyData(
+  country: CountryCode = DEFAULT_COUNTRY,
+  postalCode?: string
+): Promise<EnergyData[]> {
+  return energyDataManager.loadEnergyData(country, postalCode);
 }
 
 export function getCurrentDataSource(): DataSource {

--- a/utils/countries.ts
+++ b/utils/countries.ts
@@ -1,0 +1,85 @@
+/**
+ * Country registry – single source of truth for multi-country support.
+ *
+ * Each supported country derives its data paths, timezone, regional-data
+ * capability and default grid fees from here. Adding a new country should,
+ * in the ideal case, require only a new entry in COUNTRIES plus a matching
+ * data pipeline (see .github/workflows/fetch.yml) – no scattered `if country
+ * === 'de'` checks elsewhere.
+ *
+ * Background: Energy Charts (Fraunhofer ISE) already serves national price +
+ * renewable-share data per country via `?country=<code>`. Germany stays on the
+ * legacy flat data paths for backward compatibility with already-deployed
+ * clients; new countries live under `data/<code>/`.
+ */
+
+export type CountryCode = 'de' | 'nl';
+
+export interface CountryConfig {
+  /** Internal country code (matches storage namespace + data folder). */
+  code: CountryCode;
+  /** Country code passed to the Energy Charts API (`?country=`). */
+  energyChartsCountry: string;
+  /** Flag emoji for compact UI display. */
+  flag: string;
+  /** translations key for the human-readable country name (must exist in EN+DE). */
+  translationKey: 'countryGermany' | 'countryNetherlands';
+  /** Whether the country is still rolling out (shows a BETA badge). */
+  beta: boolean;
+  /** IANA timezone used for day boundaries in the historical store. */
+  timezone: string;
+  /** ISO 4217 currency code. All currently supported countries use EUR. */
+  currency: 'EUR';
+  /**
+   * Whether postal-code based regional data is available. Only Germany has the
+   * Energy Charts Signal API wired up (via the Cloudflare Worker); other
+   * countries expose national values only and hide the PLZ UI entirely.
+   */
+  hasRegionalData: boolean;
+  /** Path (relative to the public data root) of the national market data file. */
+  marketDataPath: string;
+  /** Path prefix (relative to the public data root) for per-day history files. */
+  historyPathPrefix: string;
+  /** Default grid fees & taxes in ¢/kWh used as the per-country starting value. */
+  defaultGridFeesCentPerKwh: number;
+}
+
+export const COUNTRIES: Record<CountryCode, CountryConfig> = {
+  de: {
+    code: 'de',
+    energyChartsCountry: 'de',
+    flag: '🇩🇪',
+    translationKey: 'countryGermany',
+    beta: false,
+    timezone: 'Europe/Berlin',
+    currency: 'EUR',
+    hasRegionalData: true,
+    // Legacy flat paths – kept for backward compatibility with deployed clients.
+    marketDataPath: 'data/marketdata.json',
+    historyPathPrefix: 'data/history/',
+    defaultGridFeesCentPerKwh: 20,
+  },
+  nl: {
+    code: 'nl',
+    energyChartsCountry: 'nl',
+    flag: '🇳🇱',
+    translationKey: 'countryNetherlands',
+    beta: true,
+    // Amsterdam == Berlin (both CET/CEST) – day boundaries align with DE.
+    timezone: 'Europe/Amsterdam',
+    currency: 'EUR',
+    hasRegionalData: false,
+    marketDataPath: 'data/nl/marketdata.json',
+    historyPathPrefix: 'data/nl/history/',
+    defaultGridFeesCentPerKwh: 20,
+  },
+};
+
+export const DEFAULT_COUNTRY: CountryCode = 'de';
+
+export const COUNTRY_CODES = Object.keys(COUNTRIES) as CountryCode[];
+
+/** Type guard for persisted/untrusted country values. */
+export function isCountryCode(value: unknown): value is CountryCode {
+  return typeof value === 'string' && value in COUNTRIES;
+}

--- a/utils/translations.ts
+++ b/utils/translations.ts
@@ -11,6 +11,11 @@ export const translations = {
     language: 'LANGUAGE',
     english: 'English',
     german: 'German',
+    // Country Section (#356)
+    country: 'COUNTRY',
+    countryGermany: 'Germany',
+    countryNetherlands: 'Netherlands',
+    countryBeta: '(BETA)',
     // Region Section
     region: 'REGION (BETA)',
     postalCode: 'Postal Code',
@@ -164,6 +169,11 @@ export const translations = {
     language: 'SPRACHE',
     english: 'English',
     german: 'Deutsch',
+    // Country Section (#356)
+    country: 'LAND',
+    countryGermany: 'Deutschland',
+    countryNetherlands: 'Niederlande',
+    countryBeta: '(BETA)',
     // Region Section
     region: 'REGION (BETA)',
     postalCode: 'Postleitzahl',


### PR DESCRIPTION
## Was & Warum

Erster Schritt der europäischen Datenexpansion (#356): Grundgerüst für Multi-Country-Support mit **Deutschland + Niederlande**, umschaltbar über einen neuen Auswahlschalter im „Personalisieren"-Modal. Für die Niederlande gibt es **nur nationale Werte – keine Postleitzahl/Regionaldaten**.

Entscheidungen (mit dem Maintainer abgestimmt): aktives Land umschalten (ein Land aktiv), MVP = nur nationale Charts für NL, Kostenwerte architektonisch pro Land vorbereitet.

## Änderungen

- **`utils/countries.ts`** *(neu)* – Länder-Registry als Single Source of Truth: Datenpfade, Zeitzone, `hasRegionalData`-Flag, Default-Netzentgelte. Neue Länder = ein Registry-Eintrag.
- **`context/CountryContext.tsx` + `hooks/useCountry.ts`** *(neu)* – aktives Land mit Persistenz (Storage-Key `country`), unabhängig von der Sprache.
- **`components/customize/CountrySection.tsx`** *(neu)* + Einbau in `CustomizeModal` – Länder-Umschalter (🇩🇪/🇳🇱, BETA-Kennzeichnung). Die **PLZ-/Regional-Sektion wird für Länder ohne Regionaldaten ausgeblendet**.
- **`services/energyDataManager.ts`** – länderbewusster Fetch-Pfad; Cache ist nach Land verschlüsselt (Wechsel lädt neu); Regional-Fetch nur für Regional-Länder; Historien-Snapshot vorerst nur für das Default-Land (bis der History-Store namespaced ist).
- **`hooks/useEnergyData.ts`** – Land als Parameter, lädt bei Länderwechsel neu.
- **`components/AppHeader.tsx`** – Titelzeile zeigt das aktive Land.
- **`utils/translations.ts`** – Länder-Labels in **EN + DE**.

## Tests
- `tsc` sauber (bis auf einen vorbestehenden, nicht berührten Fehler in `components/ui/Button.tsx`).
- ESLint: 0 Errors (nur bestehende Inline-Style-Warnungen, Muster wie `LanguageSection`).
- Jest: **282/282** grün (App- und CustomizeModal-Tests an neue Signatur/Provider angepasst).

## Hinweis / Folge-Schritte
Die **NL-Daten-Pipeline** (`public/data/nl/…` via `fetch.yml`, nur Energy Charts) ist der nächste Schritt. Bis sie gelandet ist, fällt die Auswahl von NL auf Mock-Daten zurück (Fetch-404). Danach folgt das Länder-Namespacing des History-Stores.

Closes #356 (teilweise – Schritt 1 von 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mzzhtn9j633BoHxvYjgg6M)_