### PR TITLE
fix(#356): Verlauf zeigt Historie des aktiven Landes (kein DE/NL-Mix)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -369,6 +369,7 @@ function AppContent() {
           onClose={() => setHistoryVisible(false)}
           liveData={energyData}
           gridFees={gridFees}
+          country={country}
         />
       </SafeAreaView>
       {showSplash && <SplashScreen onFinish={handleSplashFinish} version={APP_VERSION} />}

--- a/components/HistoricalDataView.tsx
+++ b/components/HistoricalDataView.tsx
@@ -13,7 +13,7 @@ import { StatusBar } from 'expo-status-bar';
 import { useLanguageContext } from '../context/LanguageContext';
 import { getThemeColors } from '../utils/theme';
 import { useSettingsContext } from '../context/SettingsContext';
-import { historicalDataStore } from '../services/historicalDataStore';
+import { historicalDataStoreForCountry } from '../services/historicalDataStore';
 import { aggregateEnergyData } from '../utils/dataAggregation';
 import {
   computeHistoricalStats,
@@ -22,6 +22,7 @@ import {
   type SeriesComparison,
 } from '../utils/historicalStats';
 import type { EnergyData } from '../utils/metrics';
+import type { CountryCode } from '../utils/countries';
 import { PriceBarChart } from './charts/PriceBarChart';
 import { RenewableBarChart } from './charts/RenewableBarChart';
 
@@ -51,6 +52,8 @@ interface HistoricalDataViewProps {
   /** Aktuelle (Live-)Daten aus dem Hauptscreen für den jüngsten Zeitraum. */
   liveData: EnergyData[];
   gridFees: number;
+  /** Aktives Land – steuert, aus welchem länder-namespaced Store gelesen wird. */
+  country: CountryCode;
 }
 
 /**
@@ -63,6 +66,7 @@ export function HistoricalDataView({
   onClose,
   liveData,
   gridFees,
+  country,
 }: HistoricalDataViewProps) {
   const { t } = useLanguageContext();
   const { theme } = useSettingsContext();
@@ -85,10 +89,12 @@ export function HistoricalDataView({
       const from = now - window;
       const prevFrom = from - window;
 
-      // Aktuelle Periode (Cache + Server-Fallback) und Vorperiode parallel laden
+      // Aktuelle Periode (Cache + Server-Fallback) und Vorperiode parallel laden,
+      // aus dem länder-namespaced Store des aktiven Landes.
+      const store = historicalDataStoreForCountry(country);
       const [historical, previousHistorical] = await Promise.all([
-        historicalDataStore.getRange(from, now),
-        historicalDataStore.getRange(prevFrom, from),
+        store.getRange(from, now),
+        store.getRange(prevFrom, from),
       ]);
       if (cancelled) return;
 
@@ -116,7 +122,7 @@ export function HistoricalDataView({
     return () => {
       cancelled = true;
     };
-  }, [visible, timeRange, liveData]);
+  }, [visible, timeRange, liveData, country]);
 
   const displayData = useMemo(() => {
     const bucket = RANGE_BUCKET_MS[timeRange];


### PR DESCRIPTION
## Was & Warum

**Bugfix zu #356:** In der „Verlauf"-Ansicht wurden im NL-Modus falsche Daten angezeigt.

### Ursache

`HistoricalDataView` las fest aus dem **DE-Singleton** `historicalDataStore`, mergte aber die `liveData` des **aktiven Landes** rein. Im 🇳🇱-Modus entstand dadurch ein **Mix**:
- jüngster Zeitraum → NL-Live-Daten (korrekt)
- ältere Tage → DE-Historie aus Cache/Server-Fallback (falsch)

### Fix

- `HistoricalDataView` bekommt das aktive Land als `country`-Prop (aus `App.tsx` / `useCountryContext`)
- liest jetzt via `historicalDataStoreForCountry(country)` aus dem korrekten **länder-namespaced** Store (eingeführt in Step 3 / PR #359)
- `country` in den `useEffect`-Deps → Länderwechsel lädt den Verlauf neu

### Verhalten danach

- **DE:** unverändert – volle Historie wie bisher
- **NL:** zeigt ausschließlich NL-Daten. Da die NL-Pipeline gerade erst startet, ist die Historie anfangs leer (`historyEmpty`) und baut sich mit der Nutzung auf – kein DE/NL-Mix mehr

## Tests

- `tsc`: keine neuen Fehler
- Jest: **282/282** grün

## Hinweis

Die `HistoryCacheSection` (Cache-Größe/„leeren") nutzt weiterhin den DE-Alias – das betrifft nur die Speicheranzeige im Customize-Modal, nicht die Verlauf-Charts. Falls gewünscht, kann sie in einem Folge-PR ebenfalls länder-aware gemacht werden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mzzhtn9j633BoHxvYjgg6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mzzhtn9j633BoHxvYjgg6M)_