### PR TITLE
chore: Release 1.8.0 – Niederlande-Support + Verlauf-Fix

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -36,7 +36,7 @@ import {
 
 SplashScreenModule.preventAutoHideAsync().catch(() => {});
 
-const APP_VERSION = '1.7.0';
+const APP_VERSION = '1.8.0';
 
 function AppContent() {
   const [showSplash, setShowSplash] = useState(true);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2026-06-25
+
+### Added
+- **Europäische Datenexpansion – Niederlande (Issue #356):** Neuer Länder-Umschalter (🇩🇪/🇳🇱) im „Personalisieren"-Modal. Für die Niederlande werden nationale Börsenpreise + Erneuerbaren-Anteile von Energy Charts angezeigt (BETA).
+  - **Länder-Registry** (`utils/countries.ts`) als Single Source of Truth: Datenpfade, Zeitzone, `hasRegionalData`-Flag, Default-Netzentgelte – neue Länder = ein Registry-Eintrag.
+  - **CountryContext + useCountry-Hook** mit Persistenz (unabhängig von der UI-Sprache).
+  - Für Länder ohne Regionaldaten (NL) wird die **PLZ-/Regional-Sektion ausgeblendet**.
+  - **NL-Datenpipeline** in `.github/workflows/fetch.yml`: holt `?country=nl` von Energy Charts (kein aWATTar), Output unter `public/data/nl/`.
+  - **History-Store länder-namespaced**: getrennte Storage-Keys + Server-Fallback-Pfade pro Land.
+
+### Fixed
+- **„Verlauf" zeigte im NL-Modus einen DE/NL-Mix** – die Verlauf-Ansicht liest jetzt aus dem länder-korrekten History-Store des aktiven Landes.
+
+---
+
 ## [1.5.3] - 2026-04-06
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,33 @@ Validation rules enforced by Husky:
      `previousAvg == 0` the object is still returned and only `deltaPct` is `null`.
      i18n key `historyStatVsPrev` (must exist in BOTH `en`+`de`).
 
+6. **Multi-Country / Europäische Datenexpansion (`utils/countries.ts`) – Issue #356:**
+   - **Country Registry is the single source of truth.** `COUNTRIES: Record<CountryCode, CountryConfig>`
+     (currently `de` + `nl`) derives data paths, timezone, `hasRegionalData`, default grid fees.
+     Adding a country ideally = one registry entry + one pipeline matrix entry, no scattered
+     `if country === 'de'` checks. `DEFAULT_COUNTRY = 'de'`.
+   - **Active country** lives in `context/CountryContext.tsx` + `hooks/useCountry.ts`
+     (persisted under storage key `country`, validated via `isCountryCode`). Independent from
+     the UI language — a user may view NL data with the German UI. Selector UI:
+     `components/customize/CountrySection.tsx` (in `CustomizeModal`, above LanguageSection).
+   - **DE stays on legacy flat paths** (`data/marketdata.json`, `data/history/`) for backward
+     compat with deployed clients; new countries live under `data/<code>/` (NL: `data/nl/`).
+   - **Data load is country-aware** (`energyDataManager`): fetch path from
+     `COUNTRIES[country].marketDataPath`; cache keyed by `dataCountry` (switch invalidates);
+     regional/PLZ fetch only when `hasRegionalData` (NL hides PLZ UI entirely).
+   - **Pipeline** (`fetch.yml`): separate NL block fetches `?country=nl` from Energy Charts
+     (NO aWATTar — DE-only), `continue-on-error` so NL failures don't block the DE update;
+     commit step stages whichever country has new data.
+   - **History store is country-namespaced** (#356 Step 3): keys
+     `energy_history_v1_<country>:<date>` + `energy_history_index_v1_<country>`; server-fallback
+     URL from `historyPathPrefix`; `dayStringFromTimestamp(ts, timezone?)` uses the registry tz.
+     Use the factory `historicalDataStoreForCountry(country)`; the `historicalDataStore`
+     singleton is just the DE alias (used by `HistoryCacheSection`).
+   - **`HistoricalDataView` ("Verlauf") takes a `country` prop** and reads from
+     `historicalDataStoreForCountry(country)` — must NOT use the bare DE singleton, or the
+     live (active-country) data merges with the wrong country's history.
+   - i18n keys (EN+DE): `country`, `countryGermany`, `countryNetherlands`, `countryBeta`.
+
 ## Common Tasks
 
 ### Adding a New Feature

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Energy Prices Germany",
     "slug": "Energy_Price_Germany",
-    "version": "1.7.0",
+    "version": "1.8.0",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -35,7 +35,7 @@
         "backgroundColor": "#ffffff"
       },
       "package": "com.sven4321.energypricegermany",
-      "versionCode": 20,
+      "versionCode": 21,
       "permissions": [
         "INTERNET",
         "ACCESS_NETWORK_STATE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "energypricegermany",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Energy price visualization for Germany with market data and renewable energy share",
   "main": "index.ts",
   "homepage": "https://s540d.github.io/Energy_Price_Germany/",


### PR DESCRIPTION
## Was

Release-Vorbereitung **1.8.0** für die europäische Datenexpansion (Niederlande) inkl. Verlauf-Fix.

## Änderungen

- **Version-Bump 1.7.0 → 1.8.0** (versionCode 20 → 21), konsistent über `package.json` / `app.json` / `App.tsx`
- **CHANGELOG.md:** neuer 1.8.0-Eintrag (Issue #356 Multi-Country + Verlauf-Fix)
- **CLAUDE.md (Memory):** neue Critical-Area „Multi-Country / Europäische Datenexpansion" – dokumentiert Country-Registry, country-aware Fetch/History und die `HistoricalDataView`-`country`-Prop-Anforderung

## Tests

- Version-Konsistenz ✅
- Jest: **282/282** grün

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mzzhtn9j633BoHxvYjgg6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mzzhtn9j633BoHxvYjgg6M)_