### PR TITLE
Release 1.8.0: Verlauf-Fix + Version-Bump (testing → main)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -36,7 +36,7 @@ import {
 
 SplashScreenModule.preventAutoHideAsync().catch(() => {});
 
-const APP_VERSION = '1.7.0';
+const APP_VERSION = '1.8.0';
 
 function AppContent() {
   const [showSplash, setShowSplash] = useState(true);

--- a/App.tsx
+++ b/App.tsx
@@ -369,6 +369,7 @@ function AppContent() {
           onClose={() => setHistoryVisible(false)}
           liveData={energyData}
           gridFees={gridFees}
+          country={country}
         />
       </SafeAreaView>
       {showSplash && <SplashScreen onFinish={handleSplashFinish} version={APP_VERSION} />}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2026-06-25
+
+### Added
+- **Europäische Datenexpansion – Niederlande (Issue #356):** Neuer Länder-Umschalter (🇩🇪/🇳🇱) im „Personalisieren"-Modal. Für die Niederlande werden nationale Börsenpreise + Erneuerbaren-Anteile von Energy Charts angezeigt (BETA).
+  - **Länder-Registry** (`utils/countries.ts`) als Single Source of Truth: Datenpfade, Zeitzone, `hasRegionalData`-Flag, Default-Netzentgelte – neue Länder = ein Registry-Eintrag.
+  - **CountryContext + useCountry-Hook** mit Persistenz (unabhängig von der UI-Sprache).
+  - Für Länder ohne Regionaldaten (NL) wird die **PLZ-/Regional-Sektion ausgeblendet**.
+  - **NL-Datenpipeline** in `.github/workflows/fetch.yml`: holt `?country=nl` von Energy Charts (kein aWATTar), Output unter `public/data/nl/`.
+  - **History-Store länder-namespaced**: getrennte Storage-Keys + Server-Fallback-Pfade pro Land.
+
+### Fixed
+- **„Verlauf" zeigte im NL-Modus einen DE/NL-Mix** – die Verlauf-Ansicht liest jetzt aus dem länder-korrekten History-Store des aktiven Landes.
+
+---
+
 ## [1.5.3] - 2026-04-06
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,33 @@ Validation rules enforced by Husky:
      `previousAvg == 0` the object is still returned and only `deltaPct` is `null`.
      i18n key `historyStatVsPrev` (must exist in BOTH `en`+`de`).
 
+6. **Multi-Country / Europäische Datenexpansion (`utils/countries.ts`) – Issue #356:**
+   - **Country Registry is the single source of truth.** `COUNTRIES: Record<CountryCode, CountryConfig>`
+     (currently `de` + `nl`) derives data paths, timezone, `hasRegionalData`, default grid fees.
+     Adding a country ideally = one registry entry + one pipeline matrix entry, no scattered
+     `if country === 'de'` checks. `DEFAULT_COUNTRY = 'de'`.
+   - **Active country** lives in `context/CountryContext.tsx` + `hooks/useCountry.ts`
+     (persisted under storage key `country`, validated via `isCountryCode`). Independent from
+     the UI language — a user may view NL data with the German UI. Selector UI:
+     `components/customize/CountrySection.tsx` (in `CustomizeModal`, above LanguageSection).
+   - **DE stays on legacy flat paths** (`data/marketdata.json`, `data/history/`) for backward
+     compat with deployed clients; new countries live under `data/<code>/` (NL: `data/nl/`).
+   - **Data load is country-aware** (`energyDataManager`): fetch path from
+     `COUNTRIES[country].marketDataPath`; cache keyed by `dataCountry` (switch invalidates);
+     regional/PLZ fetch only when `hasRegionalData` (NL hides PLZ UI entirely).
+   - **Pipeline** (`fetch.yml`): separate NL block fetches `?country=nl` from Energy Charts
+     (NO aWATTar — DE-only), `continue-on-error` so NL failures don't block the DE update;
+     commit step stages whichever country has new data.
+   - **History store is country-namespaced** (#356 Step 3): keys
+     `energy_history_v1_<country>:<date>` + `energy_history_index_v1_<country>`; server-fallback
+     URL from `historyPathPrefix`; `dayStringFromTimestamp(ts, timezone?)` uses the registry tz.
+     Use the factory `historicalDataStoreForCountry(country)`; the `historicalDataStore`
+     singleton is just the DE alias (used by `HistoryCacheSection`).
+   - **`HistoricalDataView` ("Verlauf") takes a `country` prop** and reads from
+     `historicalDataStoreForCountry(country)` — must NOT use the bare DE singleton, or the
+     live (active-country) data merges with the wrong country's history.
+   - i18n keys (EN+DE): `country`, `countryGermany`, `countryNetherlands`, `countryBeta`.
+
 ## Common Tasks
 
 ### Adding a New Feature

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Energy Prices Germany",
     "slug": "Energy_Price_Germany",
-    "version": "1.7.0",
+    "version": "1.8.0",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -35,7 +35,7 @@
         "backgroundColor": "#ffffff"
       },
       "package": "com.sven4321.energypricegermany",
-      "versionCode": 20,
+      "versionCode": 21,
       "permissions": [
         "INTERNET",
         "ACCESS_NETWORK_STATE",

--- a/components/HistoricalDataView.tsx
+++ b/components/HistoricalDataView.tsx
@@ -13,7 +13,7 @@ import { StatusBar } from 'expo-status-bar';
 import { useLanguageContext } from '../context/LanguageContext';
 import { getThemeColors } from '../utils/theme';
 import { useSettingsContext } from '../context/SettingsContext';
-import { historicalDataStore } from '../services/historicalDataStore';
+import { historicalDataStoreForCountry } from '../services/historicalDataStore';
 import { aggregateEnergyData } from '../utils/dataAggregation';
 import {
   computeHistoricalStats,
@@ -22,6 +22,7 @@ import {
   type SeriesComparison,
 } from '../utils/historicalStats';
 import type { EnergyData } from '../utils/metrics';
+import type { CountryCode } from '../utils/countries';
 import { PriceBarChart } from './charts/PriceBarChart';
 import { RenewableBarChart } from './charts/RenewableBarChart';
 
@@ -51,6 +52,8 @@ interface HistoricalDataViewProps {
   /** Aktuelle (Live-)Daten aus dem Hauptscreen für den jüngsten Zeitraum. */
   liveData: EnergyData[];
   gridFees: number;
+  /** Aktives Land – steuert, aus welchem länder-namespaced Store gelesen wird. */
+  country: CountryCode;
 }
 
 /**
@@ -63,6 +66,7 @@ export function HistoricalDataView({
   onClose,
   liveData,
   gridFees,
+  country,
 }: HistoricalDataViewProps) {
   const { t } = useLanguageContext();
   const { theme } = useSettingsContext();
@@ -85,10 +89,12 @@ export function HistoricalDataView({
       const from = now - window;
       const prevFrom = from - window;
 
-      // Aktuelle Periode (Cache + Server-Fallback) und Vorperiode parallel laden
+      // Aktuelle Periode (Cache + Server-Fallback) und Vorperiode parallel laden,
+      // aus dem länder-namespaced Store des aktiven Landes.
+      const store = historicalDataStoreForCountry(country);
       const [historical, previousHistorical] = await Promise.all([
-        historicalDataStore.getRange(from, now),
-        historicalDataStore.getRange(prevFrom, from),
+        store.getRange(from, now),
+        store.getRange(prevFrom, from),
       ]);
       if (cancelled) return;
 
@@ -116,7 +122,7 @@ export function HistoricalDataView({
     return () => {
       cancelled = true;
     };
-  }, [visible, timeRange, liveData]);
+  }, [visible, timeRange, liveData, country]);
 
   const displayData = useMemo(() => {
     const bucket = RANGE_BUCKET_MS[timeRange];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "energypricegermany",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Energy price visualization for Germany with market data and renewable energy share",
   "main": "index.ts",
   "homepage": "https://s540d.github.io/Energy_Price_Germany/",


### PR DESCRIPTION
## Release 1.8.0 (Folge-Release)

Ergänzt das vorherige Release (#360, NL-Grundgerüst Schritte 1–3) um den **Verlauf-Bugfix** und den **Version-Bump**.

### Enthalten

- **fix(#356): Verlauf zeigt Historie des aktiven Landes (#361)**
  Die „Verlauf"-Ansicht las fest aus dem DE-Store, mischte aber die Live-Daten des aktiven Landes → im NL-Modus DE/NL-Mix. Jetzt liest sie via `historicalDataStoreForCountry(country)` aus dem korrekten länder-namespaced Store.

- **chore: Release 1.8.0 (#362)**
  - Version 1.7.0 → 1.8.0 (versionCode 20 → 21), konsistent über `package.json` / `app.json` / `App.tsx`
  - CHANGELOG 1.8.0-Eintrag
  - CLAUDE.md: Multi-Country-Doku

### Test plan

- [ ] `npm run validate` grün
- [ ] Verlauf im 🇳🇱-Modus zeigt keinen DE/NL-Mix mehr (leer bis NL-Historie aufgebaut)
- [ ] Verlauf im 🇩🇪-Modus unverändert vollständig
- [ ] Version 1.8.0 wird im About-Screen angezeigt

> **Hinweis:** `main` hat Required Approvals = 1 → Admin-Bypass erforderlich: `gh pr merge <nr> --squash --admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mzzhtn9j633BoHxvYjgg6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mzzhtn9j633BoHxvYjgg6M)_