### PR TITLE
fix(#356): Falsche (DE-)Daten bei NL nach App-Neustart (Start-Race)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,13 @@ Validation rules enforced by Husky:
    - **Data load is country-aware** (`energyDataManager`): fetch path from
      `COUNTRIES[country].marketDataPath`; cache keyed by `dataCountry` (switch invalidates);
      regional/PLZ fetch only when `hasRegionalData` (NL hides PLZ UI entirely).
+   - **In-flight de-dup is scoped to the request** (`loadingCountry`/`loadingPostalCode`).
+     A load only piggybacks on the running promise when **country AND postal code match**;
+     a request for a different country awaits the in-flight load, then starts fresh. Do NOT
+     revert to an unconditional `if (isLoading) return loadingPromise` — that caused the
+     start-up race where the default DE load (before the persisted country resolved) handed
+     German data to the NL request (header showed NL, data was DE). The `finally` only clears
+     load state when `loadingPromise` is still the current one (no clobber by a newer load).
    - **Pipeline** (`fetch.yml`): separate NL block fetches `?country=nl` from Energy Charts
      (NO aWATTar — DE-only), `continue-on-error` so NL failures don't block the DE update;
      commit step stages whichever country has new data.

--- a/services/energyDataManager.test.ts
+++ b/services/energyDataManager.test.ts
@@ -441,5 +441,40 @@ describe('EnergyDataManager', () => {
       expect(data1).toEqual(data2);
       expect(data2).toEqual(data3);
     });
+
+    it('should NOT hand an in-flight country load to a different country request', async () => {
+      // Regression (#356): app starts on default DE while the persisted country
+      // (NL) is still loading; the NL request must not piggyback on the DE load.
+      const nlResponse = {
+        source: 'energy-charts',
+        data: mockMarketDataResponse.data.map(d => ({ ...d, marketprice: 999 })),
+      };
+
+      // First fetch (DE) is slow; resolve order is controlled via call index.
+      mockFetch.mockImplementation((url: string | URL | Request) => {
+        const href = String(url);
+        const isNl = href.includes('/nl/');
+        return new Promise(resolve =>
+          setTimeout(
+            () =>
+              resolve({
+                ok: true,
+                json: async () => (isNl ? nlResponse : mockMarketDataResponse),
+              } as Response),
+            50
+          )
+        );
+      });
+
+      const [deData, nlData] = await Promise.all([
+        manager.loadEnergyData('de'),
+        manager.loadEnergyData('nl'),
+      ]);
+
+      // Two distinct country loads → two fetches, each its own data.
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(deData[0].marketPrice).toBe(50.5);
+      expect(nlData[0].marketPrice).toBe(999);
+    });
   });
 });

--- a/services/energyDataManager.ts
+++ b/services/energyDataManager.ts
@@ -50,6 +50,11 @@ export class EnergyDataManager {
   private currentDataSource: DataSource = 'none';
   private isLoading: boolean = false;
   private loadingPromise: Promise<EnergyData[]> | null = null;
+  // Scope of the in-flight load – an identical request may de-dupe onto the
+  // running promise, but a request for a DIFFERENT country/postal code must not
+  // (otherwise the initial DE load would hand its data back to an NL request).
+  private loadingCountry: CountryCode | null = null;
+  private loadingPostalCode: string | undefined = undefined;
 
   // Regional data cache (delegated to dedicated module)
   private regionalCache = new RegionalDataCache();
@@ -175,9 +180,22 @@ export class EnergyDataManager {
     country: CountryCode = DEFAULT_COUNTRY,
     postalCode?: string
   ): Promise<EnergyData[]> {
-    // Wenn bereits ein Ladevorgang läuft, warte darauf
+    // Wenn bereits ein Ladevorgang läuft: nur dann darauf warten, wenn es
+    // exakt dieselbe Anfrage ist (gleiches Land + PLZ). Eine Anfrage für ein
+    // ANDERES Land darf nicht das laufende Promise zurückbekommen – sonst gibt
+    // der initiale DE-Ladevorgang (Default, solange das persistierte Land noch
+    // lädt) seine deutschen Daten an eine NL-Anfrage zurück.
     if (this.isLoading && this.loadingPromise) {
-      return this.loadingPromise;
+      if (this.loadingCountry === country && this.loadingPostalCode === postalCode) {
+        return this.loadingPromise;
+      }
+      // Anderer Ladevorgang in flight – erst abwarten (dessen Cache-Write
+      // abschließen lassen), dann einen frischen, korrekt zugeordneten starten.
+      try {
+        await this.loadingPromise;
+      } catch {
+        // egal – wir laden unten ohnehin neu
+      }
     }
 
     const regionalEnabled = COUNTRIES[country].hasRegionalData;
@@ -197,14 +215,22 @@ export class EnergyDataManager {
 
     // Starte Ladevorgang
     this.isLoading = true;
-    this.loadingPromise = this.performDataLoad(country, postalCode);
+    this.loadingCountry = country;
+    this.loadingPostalCode = postalCode;
+    const promise = this.performDataLoad(country, postalCode);
+    this.loadingPromise = promise;
 
     try {
-      const data = await this.loadingPromise;
-      return data;
+      return await promise;
     } finally {
-      this.isLoading = false;
-      this.loadingPromise = null;
+      // Nur aufräumen, wenn unser Promise noch das aktuelle ist (ein neuerer
+      // Ladevorgang könnte es bereits ersetzt haben).
+      if (this.loadingPromise === promise) {
+        this.isLoading = false;
+        this.loadingPromise = null;
+        this.loadingCountry = null;
+        this.loadingPostalCode = undefined;
+      }
     }
   }
 


### PR DESCRIPTION
## Bug

Bei NL als gespeichertem Land zeigte die App nach Neustart oben links korrekt „Niederlande", aber **deutsche Daten**.

## Ursache (Race-Condition beim Start)

1. App startet → `useCountry` liefert zunächst den Default `'de'` (Storage wird async geladen) → `loadEnergyData('de')` startet, `isLoading=true`.
2. Storage geladen → `country` wird `'nl'` → `useEnergyData`-Effekt feuert erneut → `loadEnergyData('nl')`.
3. Der In-flight-Dedup-Guard in `loadEnergyData` prüfte **das Land nicht** und gab das noch laufende **DE-Promise** zurück.
4. Ergebnis: Header zeigt „Niederlande" (aus dem country-State), die Daten stammen aber aus dem DE-Ladevorgang.

## Fix (`services/energyDataManager.ts`)

- In-flight-Dedup greift nur noch bei **identischer Anfrage** (gleiches Land **und** PLZ)
- Anfrage für ein anderes Land **wartet den laufenden Load ab** und startet dann einen frischen, korrekt zugeordneten
- Neue Felder `loadingCountry` / `loadingPostalCode` tracken den Scope des laufenden Promises
- `finally` räumt nur auf, wenn das Promise noch das aktuelle ist (kein Clobbering durch einen neueren Load)

## Tests

- Neuer Regressionstest: paralleler DE+NL-Load liefert **getrennte** Daten (2 Fetches, keine Vermischung)
- Bestehender „deduplicate concurrent requests"-Test (gleiches Land) bleibt grün
- Jest: **283/283** grün · `tsc` ohne neue Fehler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mzzhtn9j633BoHxvYjgg6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mzzhtn9j633BoHxvYjgg6M)_