### PR TITLE
chore: Release 1.8.1 – NL-Start-Race-Fix

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -36,7 +36,7 @@ import {
 
 SplashScreenModule.preventAutoHideAsync().catch(() => {});
 
-const APP_VERSION = '1.8.0';
+const APP_VERSION = '1.8.1';
 
 function AppContent() {
   const [showSplash, setShowSplash] = useState(true);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.1] - 2026-06-25
+
+### Fixed
+- **Falsche (deutsche) Daten bei den Niederlanden nach App-Neustart** – Race-Condition beim Start: der noch laufende Default-DE-Ladevorgang lieferte seine Daten an die NL-Anfrage zurück. Der In-flight-Dedup im Daten-Manager ist jetzt nach Land + PLZ gescoped.
+
 ## [1.8.0] - 2026-06-25
 
 ### Added

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Energy Prices Germany",
     "slug": "Energy_Price_Germany",
-    "version": "1.8.0",
+    "version": "1.8.1",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -35,7 +35,7 @@
         "backgroundColor": "#ffffff"
       },
       "package": "com.sven4321.energypricegermany",
-      "versionCode": 21,
+      "versionCode": 22,
       "permissions": [
         "INTERNET",
         "ACCESS_NETWORK_STATE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "energypricegermany",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Energy price visualization for Germany with market data and renewable energy share",
   "main": "index.ts",
   "homepage": "https://s540d.github.io/Energy_Price_Germany/",


### PR DESCRIPTION
## Was

Patch-Release **1.8.1** – enthält den NL-Start-Race-Fix (PR #364, bereits auf `testing`).

## Änderungen

- **Version-Bump 1.8.0 → 1.8.1** (versionCode 21 → 22), konsistent über `package.json` / `app.json` / `App.tsx`
- **CHANGELOG.md:** 1.8.1-Eintrag (Start-Race-Fix)

## Tests

- Version-Konsistenz ✅
- (Code-Fix selbst bereits in #364 getestet: Jest 283/283)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mzzhtn9j633BoHxvYjgg6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mzzhtn9j633BoHxvYjgg6M)_