### PR TITLE
Release 1.8.1: NL-Start-Race-Fix (testing → main)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -36,7 +36,7 @@ import {
 
 SplashScreenModule.preventAutoHideAsync().catch(() => {});
 
-const APP_VERSION = '1.8.0';
+const APP_VERSION = '1.8.1';
 
 function AppContent() {
   const [showSplash, setShowSplash] = useState(true);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.1] - 2026-06-25
+
+### Fixed
+- **Falsche (deutsche) Daten bei den Niederlanden nach App-Neustart** – Race-Condition beim Start: der noch laufende Default-DE-Ladevorgang lieferte seine Daten an die NL-Anfrage zurück. Der In-flight-Dedup im Daten-Manager ist jetzt nach Land + PLZ gescoped.
+
 ## [1.8.0] - 2026-06-25
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,13 @@ Validation rules enforced by Husky:
    - **Data load is country-aware** (`energyDataManager`): fetch path from
      `COUNTRIES[country].marketDataPath`; cache keyed by `dataCountry` (switch invalidates);
      regional/PLZ fetch only when `hasRegionalData` (NL hides PLZ UI entirely).
+   - **In-flight de-dup is scoped to the request** (`loadingCountry`/`loadingPostalCode`).
+     A load only piggybacks on the running promise when **country AND postal code match**;
+     a request for a different country awaits the in-flight load, then starts fresh. Do NOT
+     revert to an unconditional `if (isLoading) return loadingPromise` — that caused the
+     start-up race where the default DE load (before the persisted country resolved) handed
+     German data to the NL request (header showed NL, data was DE). The `finally` only clears
+     load state when `loadingPromise` is still the current one (no clobber by a newer load).
    - **Pipeline** (`fetch.yml`): separate NL block fetches `?country=nl` from Energy Charts
      (NO aWATTar — DE-only), `continue-on-error` so NL failures don't block the DE update;
      commit step stages whichever country has new data.

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Energy Prices Germany",
     "slug": "Energy_Price_Germany",
-    "version": "1.8.0",
+    "version": "1.8.1",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -35,7 +35,7 @@
         "backgroundColor": "#ffffff"
       },
       "package": "com.sven4321.energypricegermany",
-      "versionCode": 21,
+      "versionCode": 22,
       "permissions": [
         "INTERNET",
         "ACCESS_NETWORK_STATE",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "energypricegermany",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Energy price visualization for Germany with market data and renewable energy share",
   "main": "index.ts",
   "homepage": "https://s540d.github.io/Energy_Price_Germany/",

--- a/services/energyDataManager.test.ts
+++ b/services/energyDataManager.test.ts
@@ -441,5 +441,40 @@ describe('EnergyDataManager', () => {
       expect(data1).toEqual(data2);
       expect(data2).toEqual(data3);
     });
+
+    it('should NOT hand an in-flight country load to a different country request', async () => {
+      // Regression (#356): app starts on default DE while the persisted country
+      // (NL) is still loading; the NL request must not piggyback on the DE load.
+      const nlResponse = {
+        source: 'energy-charts',
+        data: mockMarketDataResponse.data.map(d => ({ ...d, marketprice: 999 })),
+      };
+
+      // First fetch (DE) is slow; resolve order is controlled via call index.
+      mockFetch.mockImplementation((url: string | URL | Request) => {
+        const href = String(url);
+        const isNl = href.includes('/nl/');
+        return new Promise(resolve =>
+          setTimeout(
+            () =>
+              resolve({
+                ok: true,
+                json: async () => (isNl ? nlResponse : mockMarketDataResponse),
+              } as Response),
+            50
+          )
+        );
+      });
+
+      const [deData, nlData] = await Promise.all([
+        manager.loadEnergyData('de'),
+        manager.loadEnergyData('nl'),
+      ]);
+
+      // Two distinct country loads → two fetches, each its own data.
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(deData[0].marketPrice).toBe(50.5);
+      expect(nlData[0].marketPrice).toBe(999);
+    });
   });
 });

--- a/services/energyDataManager.ts
+++ b/services/energyDataManager.ts
@@ -50,6 +50,11 @@ export class EnergyDataManager {
   private currentDataSource: DataSource = 'none';
   private isLoading: boolean = false;
   private loadingPromise: Promise<EnergyData[]> | null = null;
+  // Scope of the in-flight load – an identical request may de-dupe onto the
+  // running promise, but a request for a DIFFERENT country/postal code must not
+  // (otherwise the initial DE load would hand its data back to an NL request).
+  private loadingCountry: CountryCode | null = null;
+  private loadingPostalCode: string | undefined = undefined;
 
   // Regional data cache (delegated to dedicated module)
   private regionalCache = new RegionalDataCache();
@@ -175,9 +180,22 @@ export class EnergyDataManager {
     country: CountryCode = DEFAULT_COUNTRY,
     postalCode?: string
   ): Promise<EnergyData[]> {
-    // Wenn bereits ein Ladevorgang läuft, warte darauf
+    // Wenn bereits ein Ladevorgang läuft: nur dann darauf warten, wenn es
+    // exakt dieselbe Anfrage ist (gleiches Land + PLZ). Eine Anfrage für ein
+    // ANDERES Land darf nicht das laufende Promise zurückbekommen – sonst gibt
+    // der initiale DE-Ladevorgang (Default, solange das persistierte Land noch
+    // lädt) seine deutschen Daten an eine NL-Anfrage zurück.
     if (this.isLoading && this.loadingPromise) {
-      return this.loadingPromise;
+      if (this.loadingCountry === country && this.loadingPostalCode === postalCode) {
+        return this.loadingPromise;
+      }
+      // Anderer Ladevorgang in flight – erst abwarten (dessen Cache-Write
+      // abschließen lassen), dann einen frischen, korrekt zugeordneten starten.
+      try {
+        await this.loadingPromise;
+      } catch {
+        // egal – wir laden unten ohnehin neu
+      }
     }
 
     const regionalEnabled = COUNTRIES[country].hasRegionalData;
@@ -197,14 +215,22 @@ export class EnergyDataManager {
 
     // Starte Ladevorgang
     this.isLoading = true;
-    this.loadingPromise = this.performDataLoad(country, postalCode);
+    this.loadingCountry = country;
+    this.loadingPostalCode = postalCode;
+    const promise = this.performDataLoad(country, postalCode);
+    this.loadingPromise = promise;
 
     try {
-      const data = await this.loadingPromise;
-      return data;
+      return await promise;
     } finally {
-      this.isLoading = false;
-      this.loadingPromise = null;
+      // Nur aufräumen, wenn unser Promise noch das aktuelle ist (ein neuerer
+      // Ladevorgang könnte es bereits ersetzt haben).
+      if (this.loadingPromise === promise) {
+        this.isLoading = false;
+        this.loadingPromise = null;
+        this.loadingCountry = null;
+        this.loadingPostalCode = undefined;
+      }
     }
   }
 


### PR DESCRIPTION
## Release 1.8.1 (Patch)

Bringt den **NL-Start-Race-Fix** in die Produktion.

### Enthalten

- **fix(#356): Falsche (DE-)Daten bei NL nach App-Neustart (#364)**
  Race-Condition beim Start: Der noch laufende Default-DE-Ladevorgang (bevor das persistierte Land aufgelöst war) gab seine Daten an die NL-Anfrage zurück → Header zeigte „Niederlande", die Daten waren aber deutsch. Der In-flight-Dedup im Daten-Manager ist jetzt nach **Land + PLZ** gescoped.

- **chore: Release 1.8.1 (#365)**
  - Version 1.8.0 → 1.8.1 (versionCode 21 → 22), konsistent über `package.json` / `app.json` / `App.tsx`
  - CHANGELOG 1.8.1-Eintrag

### Test plan

- [ ] `npm run validate` grün
- [ ] App mit NL als gespeichertem Land schließen & neu öffnen → es werden **NL-Daten** angezeigt (kein DE-Mix)
- [ ] DE-Verhalten unverändert
- [ ] Version 1.8.1 im About-Screen

> **Hinweis:** `main` hat Required Approvals = 1 → Admin-Bypass erforderlich: `gh pr merge <nr> --squash --admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mzzhtn9j633BoHxvYjgg6M

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mzzhtn9j633BoHxvYjgg6M)_