### PR TITLE
feat(#368): Österreich & Schweiz – Phase 1 Europa-Expansion

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -341,6 +341,9 @@ jobs:
 
       # ─── Netherlands (NL) – Energy Charts only, no aWATTar ───────────────────
 
+      - name: Rate-limit guard before NL
+        run: sleep 2
+
       - name: Try fetching NL data from Energy Charts API
         id: energy_charts_nl
         continue-on-error: true
@@ -623,10 +626,526 @@ jobs:
             echo "🧹 Cleaned up NL temporary file (no new data)"
           fi
 
+      # ─── Austria (AT) – Energy Charts only ────────────────────────────────────
+
+      - name: Rate-limit guard before AT
+        run: sleep 2
+
+      - name: Try fetching AT data from Energy Charts API
+        id: energy_charts_at
+        continue-on-error: true
+        run: |
+          mkdir -p public/data/at
+
+          # Energy Charts: Renewable share forecast (15-min resolution)
+          curl -fsSL "https://api.energy-charts.info/ren_share_forecast?country=at" -o public/data/at/renewable_raw.json || exit 1
+
+          # Energy Charts: Day-ahead prices (15-min resolution)
+          curl -fsSL "https://api.energy-charts.info/price?country=at" -o public/data/at/price_raw.json || exit 1
+
+          echo "success=true" >> $GITHUB_OUTPUT
+
+      - name: Process Energy Charts AT data
+        if: steps.energy_charts_at.outputs.success == 'true'
+        continue-on-error: true
+        run: |
+          node -e '
+          const fs = require("fs");
+
+          try {
+            const renewable = JSON.parse(fs.readFileSync("public/data/at/renewable_raw.json", "utf8"));
+            const price = JSON.parse(fs.readFileSync("public/data/at/price_raw.json", "utf8"));
+
+            const priceMap = new Map();
+            const renewableMap = new Map();
+            const allTimestamps = new Set();
+
+            if (price.unix_seconds && price.price) {
+              price.unix_seconds.forEach((ts, i) => {
+                const timestamp_ms = ts * 1000;
+                priceMap.set(timestamp_ms, price.price[i]);
+                allTimestamps.add(timestamp_ms);
+              });
+            }
+
+            if (renewable.unix_seconds && renewable.ren_share) {
+              renewable.unix_seconds.forEach((ts, i) => {
+                const timestamp_ms = ts * 1000;
+                renewableMap.set(timestamp_ms, renewable.ren_share[i]);
+                allTimestamps.add(timestamp_ms);
+              });
+            }
+
+            const merged = Array.from(allTimestamps).map(timestamp_ms => ({
+              start_timestamp: timestamp_ms,
+              end_timestamp: timestamp_ms + 15 * 60 * 1000,
+              marketprice: priceMap.get(timestamp_ms) || null,
+              renewable_share: renewableMap.get(timestamp_ms) || null,
+              unit: "Eur/MWh",
+              interpolated: false
+            }));
+
+            merged.sort((a, b) => a.start_timestamp - b.start_timestamp);
+
+            console.log("Successfully processed Energy Charts AT data:");
+            console.log("- Price points: " + priceMap.size);
+            console.log("- Renewable points: " + renewableMap.size);
+            console.log("- Total merged points: " + merged.length);
+
+            fs.writeFileSync("public/data/at/marketdata_new.json", JSON.stringify({
+              object: "list",
+              source: "energy-charts",
+              data: merged
+            }, null, 2));
+
+          } catch (error) {
+            console.error("Error processing Energy Charts AT data:", error);
+            process.exit(1);
+          }
+          '
+          rm -f public/data/at/renewable_raw.json public/data/at/price_raw.json
+
+      - name: Validate AT market data
+        if: steps.energy_charts_at.outputs.success == 'true'
+        continue-on-error: true
+        run: |
+          if ! node -e '
+          const fs = require("fs");
+
+          const file = "public/data/at/marketdata_new.json";
+          if (!fs.existsSync(file)) {
+            console.error("❌ at/marketdata_new.json not found");
+            process.exit(1);
+          }
+
+          let parsed;
+          try {
+            parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+          } catch (e) {
+            console.error("❌ Invalid JSON in at/marketdata_new.json:", e.message);
+            process.exit(1);
+          }
+
+          const errors = [];
+          if (parsed.object !== "list") errors.push("Missing or wrong \"object\" field");
+          if (!["energy-charts"].includes(parsed.source)) errors.push("Invalid source: " + parsed.source);
+          if (!Array.isArray(parsed.data)) errors.push("\"data\" is not an array");
+
+          if (errors.length > 0) {
+            errors.forEach(e => console.error("❌ " + e));
+            process.exit(1);
+          }
+
+          const data = parsed.data;
+          if (data.length < 96) {
+            console.error("❌ Too few data points: " + data.length + " (minimum 96)");
+            process.exit(1);
+          }
+
+          const priceCount = data.filter(d => typeof d.marketprice === "number" && isFinite(d.marketprice)).length;
+          if (priceCount === 0) {
+            console.error("❌ All marketprice values are null/invalid – no usable price data");
+            process.exit(1);
+          }
+
+          const now = Date.now();
+          const validTs = data.map(d => d.start_timestamp).filter(ts => typeof ts === "number" && isFinite(ts) && ts > 0);
+          const maxTs = Math.max(...validTs);
+          const ageHours = (now - maxTs) / (1000 * 60 * 60);
+          if (ageHours > 36) {
+            console.error("❌ Newest data point is " + ageHours.toFixed(1) + "h old (max 36h)");
+            process.exit(1);
+          }
+
+          console.log("✅ AT quality check passed:");
+          console.log("   Data points : " + data.length);
+          console.log("   Price points: " + priceCount);
+          console.log("   Newest entry: " + new Date(maxTs).toISOString() + " (" + ageHours.toFixed(1) + "h ago)");
+          console.log("   Source      : " + parsed.source);
+          '; then
+            echo "⚠️ AT validation failed – removing temporary file"
+            rm -f public/data/at/marketdata_new.json
+          fi
+
+      - name: Compare with previous AT data
+        id: compare_at
+        run: |
+          if [ ! -f "public/data/at/marketdata_new.json" ]; then
+            echo "new_data=false" >> $GITHUB_OUTPUT
+            echo "ℹ️ AT market data not available – skipping AT update"
+            exit 0
+          fi
+
+          NEW_TS=$(jq '[.data[].start_timestamp] | max' public/data/at/marketdata_new.json)
+
+          if [ -f public/data/at/marketdata.json ]; then
+            OLD_TS=$(jq '[.data[].start_timestamp] | max' public/data/at/marketdata.json)
+          else
+            OLD_TS=""
+          fi
+
+          if [ "$OLD_TS" != "$NEW_TS" ]; then
+            echo "new_data=true" >> $GITHUB_OUTPUT
+          else
+            echo "new_data=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update at/marketdata.json and create archive
+        if: steps.compare_at.outputs.new_data == 'true'
+        run: |
+          ARCHIVE_NAME="marketdata_$(date -u +"%Y-%m-%dT%H").json"
+          mkdir -p public/data/at/archive
+          cp public/data/at/marketdata_new.json "public/data/at/archive/$ARCHIVE_NAME"
+          mv public/data/at/marketdata_new.json public/data/at/marketdata.json
+          echo "✓ Updated at/marketdata.json"
+          echo "✓ Created AT archive: $ARCHIVE_NAME"
+
+      - name: Create daily AT history file
+        if: steps.compare_at.outputs.new_data == 'true'
+        run: |
+          mkdir -p public/data/at/history
+
+          node -e '
+          const fs = require("fs");
+          const data = JSON.parse(fs.readFileSync("public/data/at/marketdata.json", "utf8"));
+
+          const now = new Date();
+          const yesterday = new Date(now);
+          yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+          const yesterdayStr = yesterday.toISOString().slice(0, 10);
+
+          const dayStart = new Date(yesterdayStr + "T00:00:00Z").getTime();
+          const dayEnd = new Date(yesterdayStr + "T23:59:59Z").getTime();
+
+          const yesterdayData = data.data.filter(item =>
+            item.start_timestamp >= dayStart && item.start_timestamp <= dayEnd
+          );
+
+          const historyFile = "public/data/at/history/" + yesterdayStr + ".json";
+
+          if (yesterdayData.length >= 92) {
+            if (!fs.existsSync(historyFile)) {
+              fs.writeFileSync(historyFile, JSON.stringify({
+                date: yesterdayStr,
+                source: data.source,
+                data: yesterdayData
+              }, null, 2));
+              console.log("✓ Created AT history file: " + yesterdayStr + ".json (" + yesterdayData.length + " points)");
+            } else {
+              console.log("✓ AT history file already exists: " + yesterdayStr + ".json");
+            }
+          } else {
+            console.log("⚠️ Incomplete AT data for " + yesterdayStr + " (" + yesterdayData.length + "/96 points) - skipping");
+          }
+          '
+
+      - name: Cleanup old AT archives (keep 90 days)
+        if: steps.compare_at.outputs.new_data == 'true'
+        run: |
+          ARCHIVE_DIR="public/data/at/archive"
+          DAYS_TO_KEEP=90
+          CUTOFF_DATE=$(date -u -d "$DAYS_TO_KEEP days ago" +"%Y-%m-%d" 2>/dev/null || date -u -v-${DAYS_TO_KEEP}d +"%Y-%m-%d")
+          DELETED=0
+          for file in "$ARCHIVE_DIR"/marketdata_*.json; do
+            if [ -f "$file" ]; then
+              FILE_DATE=$(basename "$file" | sed 's/marketdata_\([0-9-]*\)T.*/\1/')
+              if [ "$FILE_DATE" \< "$CUTOFF_DATE" ]; then
+                rm "$file"
+                DELETED=$((DELETED + 1))
+              fi
+            fi
+          done
+          [ $DELETED -gt 0 ] && echo "🧹 Cleaned up $DELETED old AT archives" || echo "✓ No old AT archives to clean up"
+
+      - name: Cleanup old AT history files (keep 90 days)
+        if: steps.compare_at.outputs.new_data == 'true'
+        run: |
+          HISTORY_DIR="public/data/at/history"
+          DAYS_TO_KEEP=90
+          if [ -d "$HISTORY_DIR" ]; then
+            CUTOFF_DATE=$(date -u -d "$DAYS_TO_KEEP days ago" +"%Y-%m-%d" 2>/dev/null || date -u -v-${DAYS_TO_KEEP}d +"%Y-%m-%d")
+            DELETED=0
+            for file in "$HISTORY_DIR"/*.json; do
+              if [ -f "$file" ]; then
+                FILE_DATE=$(basename "$file" .json)
+                [ "$FILE_DATE" \< "$CUTOFF_DATE" ] && rm "$file" && DELETED=$((DELETED + 1))
+              fi
+            done
+            [ $DELETED -gt 0 ] && echo "🧹 Cleaned up $DELETED old AT history files" || echo "✓ No old AT history files to clean up"
+          fi
+
+      - name: Cleanup AT temporary file
+        if: steps.compare_at.outputs.new_data == 'false'
+        run: |
+          if [ -f public/data/at/marketdata_new.json ]; then
+            rm -f public/data/at/marketdata_new.json
+            echo "🧹 Cleaned up AT temporary file (no new data)"
+          fi
+
+      # ─── Switzerland (CH) – Energy Charts only ────────────────────────────────
+
+      - name: Rate-limit guard before CH
+        run: sleep 2
+
+      - name: Try fetching CH data from Energy Charts API
+        id: energy_charts_ch
+        continue-on-error: true
+        run: |
+          mkdir -p public/data/ch
+
+          # Energy Charts: Renewable share forecast (15-min resolution)
+          curl -fsSL "https://api.energy-charts.info/ren_share_forecast?country=ch" -o public/data/ch/renewable_raw.json || exit 1
+
+          # Energy Charts: Day-ahead prices (15-min resolution)
+          curl -fsSL "https://api.energy-charts.info/price?country=ch" -o public/data/ch/price_raw.json || exit 1
+
+          echo "success=true" >> $GITHUB_OUTPUT
+
+      - name: Process Energy Charts CH data
+        if: steps.energy_charts_ch.outputs.success == 'true'
+        continue-on-error: true
+        run: |
+          node -e '
+          const fs = require("fs");
+
+          try {
+            const renewable = JSON.parse(fs.readFileSync("public/data/ch/renewable_raw.json", "utf8"));
+            const price = JSON.parse(fs.readFileSync("public/data/ch/price_raw.json", "utf8"));
+
+            const priceMap = new Map();
+            const renewableMap = new Map();
+            const allTimestamps = new Set();
+
+            if (price.unix_seconds && price.price) {
+              price.unix_seconds.forEach((ts, i) => {
+                const timestamp_ms = ts * 1000;
+                priceMap.set(timestamp_ms, price.price[i]);
+                allTimestamps.add(timestamp_ms);
+              });
+            }
+
+            if (renewable.unix_seconds && renewable.ren_share) {
+              renewable.unix_seconds.forEach((ts, i) => {
+                const timestamp_ms = ts * 1000;
+                renewableMap.set(timestamp_ms, renewable.ren_share[i]);
+                allTimestamps.add(timestamp_ms);
+              });
+            }
+
+            const merged = Array.from(allTimestamps).map(timestamp_ms => ({
+              start_timestamp: timestamp_ms,
+              end_timestamp: timestamp_ms + 15 * 60 * 1000,
+              marketprice: priceMap.get(timestamp_ms) || null,
+              renewable_share: renewableMap.get(timestamp_ms) || null,
+              unit: "Eur/MWh",
+              interpolated: false
+            }));
+
+            merged.sort((a, b) => a.start_timestamp - b.start_timestamp);
+
+            console.log("Successfully processed Energy Charts CH data:");
+            console.log("- Price points: " + priceMap.size);
+            console.log("- Renewable points: " + renewableMap.size);
+            console.log("- Total merged points: " + merged.length);
+
+            fs.writeFileSync("public/data/ch/marketdata_new.json", JSON.stringify({
+              object: "list",
+              source: "energy-charts",
+              data: merged
+            }, null, 2));
+
+          } catch (error) {
+            console.error("Error processing Energy Charts CH data:", error);
+            process.exit(1);
+          }
+          '
+          rm -f public/data/ch/renewable_raw.json public/data/ch/price_raw.json
+
+      - name: Validate CH market data
+        if: steps.energy_charts_ch.outputs.success == 'true'
+        continue-on-error: true
+        run: |
+          if ! node -e '
+          const fs = require("fs");
+
+          const file = "public/data/ch/marketdata_new.json";
+          if (!fs.existsSync(file)) {
+            console.error("❌ ch/marketdata_new.json not found");
+            process.exit(1);
+          }
+
+          let parsed;
+          try {
+            parsed = JSON.parse(fs.readFileSync(file, "utf8"));
+          } catch (e) {
+            console.error("❌ Invalid JSON in ch/marketdata_new.json:", e.message);
+            process.exit(1);
+          }
+
+          const errors = [];
+          if (parsed.object !== "list") errors.push("Missing or wrong \"object\" field");
+          if (!["energy-charts"].includes(parsed.source)) errors.push("Invalid source: " + parsed.source);
+          if (!Array.isArray(parsed.data)) errors.push("\"data\" is not an array");
+
+          if (errors.length > 0) {
+            errors.forEach(e => console.error("❌ " + e));
+            process.exit(1);
+          }
+
+          const data = parsed.data;
+          if (data.length < 96) {
+            console.error("❌ Too few data points: " + data.length + " (minimum 96)");
+            process.exit(1);
+          }
+
+          const priceCount = data.filter(d => typeof d.marketprice === "number" && isFinite(d.marketprice)).length;
+          if (priceCount === 0) {
+            console.error("❌ All marketprice values are null/invalid – no usable price data");
+            process.exit(1);
+          }
+
+          const now = Date.now();
+          const validTs = data.map(d => d.start_timestamp).filter(ts => typeof ts === "number" && isFinite(ts) && ts > 0);
+          const maxTs = Math.max(...validTs);
+          const ageHours = (now - maxTs) / (1000 * 60 * 60);
+          if (ageHours > 36) {
+            console.error("❌ Newest data point is " + ageHours.toFixed(1) + "h old (max 36h)");
+            process.exit(1);
+          }
+
+          console.log("✅ CH quality check passed:");
+          console.log("   Data points : " + data.length);
+          console.log("   Price points: " + priceCount);
+          console.log("   Newest entry: " + new Date(maxTs).toISOString() + " (" + ageHours.toFixed(1) + "h ago)");
+          console.log("   Source      : " + parsed.source);
+          '; then
+            echo "⚠️ CH validation failed – removing temporary file"
+            rm -f public/data/ch/marketdata_new.json
+          fi
+
+      - name: Compare with previous CH data
+        id: compare_ch
+        run: |
+          if [ ! -f "public/data/ch/marketdata_new.json" ]; then
+            echo "new_data=false" >> $GITHUB_OUTPUT
+            echo "ℹ️ CH market data not available – skipping CH update"
+            exit 0
+          fi
+
+          NEW_TS=$(jq '[.data[].start_timestamp] | max' public/data/ch/marketdata_new.json)
+
+          if [ -f public/data/ch/marketdata.json ]; then
+            OLD_TS=$(jq '[.data[].start_timestamp] | max' public/data/ch/marketdata.json)
+          else
+            OLD_TS=""
+          fi
+
+          if [ "$OLD_TS" != "$NEW_TS" ]; then
+            echo "new_data=true" >> $GITHUB_OUTPUT
+          else
+            echo "new_data=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update ch/marketdata.json and create archive
+        if: steps.compare_ch.outputs.new_data == 'true'
+        run: |
+          ARCHIVE_NAME="marketdata_$(date -u +"%Y-%m-%dT%H").json"
+          mkdir -p public/data/ch/archive
+          cp public/data/ch/marketdata_new.json "public/data/ch/archive/$ARCHIVE_NAME"
+          mv public/data/ch/marketdata_new.json public/data/ch/marketdata.json
+          echo "✓ Updated ch/marketdata.json"
+          echo "✓ Created CH archive: $ARCHIVE_NAME"
+
+      - name: Create daily CH history file
+        if: steps.compare_ch.outputs.new_data == 'true'
+        run: |
+          mkdir -p public/data/ch/history
+
+          node -e '
+          const fs = require("fs");
+          const data = JSON.parse(fs.readFileSync("public/data/ch/marketdata.json", "utf8"));
+
+          const now = new Date();
+          const yesterday = new Date(now);
+          yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+          const yesterdayStr = yesterday.toISOString().slice(0, 10);
+
+          const dayStart = new Date(yesterdayStr + "T00:00:00Z").getTime();
+          const dayEnd = new Date(yesterdayStr + "T23:59:59Z").getTime();
+
+          const yesterdayData = data.data.filter(item =>
+            item.start_timestamp >= dayStart && item.start_timestamp <= dayEnd
+          );
+
+          const historyFile = "public/data/ch/history/" + yesterdayStr + ".json";
+
+          if (yesterdayData.length >= 92) {
+            if (!fs.existsSync(historyFile)) {
+              fs.writeFileSync(historyFile, JSON.stringify({
+                date: yesterdayStr,
+                source: data.source,
+                data: yesterdayData
+              }, null, 2));
+              console.log("✓ Created CH history file: " + yesterdayStr + ".json (" + yesterdayData.length + " points)");
+            } else {
+              console.log("✓ CH history file already exists: " + yesterdayStr + ".json");
+            }
+          } else {
+            console.log("⚠️ Incomplete CH data for " + yesterdayStr + " (" + yesterdayData.length + "/96 points) - skipping");
+          }
+          '
+
+      - name: Cleanup old CH archives (keep 90 days)
+        if: steps.compare_ch.outputs.new_data == 'true'
+        run: |
+          ARCHIVE_DIR="public/data/ch/archive"
+          DAYS_TO_KEEP=90
+          CUTOFF_DATE=$(date -u -d "$DAYS_TO_KEEP days ago" +"%Y-%m-%d" 2>/dev/null || date -u -v-${DAYS_TO_KEEP}d +"%Y-%m-%d")
+          DELETED=0
+          for file in "$ARCHIVE_DIR"/marketdata_*.json; do
+            if [ -f "$file" ]; then
+              FILE_DATE=$(basename "$file" | sed 's/marketdata_\([0-9-]*\)T.*/\1/')
+              if [ "$FILE_DATE" \< "$CUTOFF_DATE" ]; then
+                rm "$file"
+                DELETED=$((DELETED + 1))
+              fi
+            fi
+          done
+          [ $DELETED -gt 0 ] && echo "🧹 Cleaned up $DELETED old CH archives" || echo "✓ No old CH archives to clean up"
+
+      - name: Cleanup old CH history files (keep 90 days)
+        if: steps.compare_ch.outputs.new_data == 'true'
+        run: |
+          HISTORY_DIR="public/data/ch/history"
+          DAYS_TO_KEEP=90
+          if [ -d "$HISTORY_DIR" ]; then
+            CUTOFF_DATE=$(date -u -d "$DAYS_TO_KEEP days ago" +"%Y-%m-%d" 2>/dev/null || date -u -v-${DAYS_TO_KEEP}d +"%Y-%m-%d")
+            DELETED=0
+            for file in "$HISTORY_DIR"/*.json; do
+              if [ -f "$file" ]; then
+                FILE_DATE=$(basename "$file" .json)
+                [ "$FILE_DATE" \< "$CUTOFF_DATE" ] && rm "$file" && DELETED=$((DELETED + 1))
+              fi
+            done
+            [ $DELETED -gt 0 ] && echo "🧹 Cleaned up $DELETED old CH history files" || echo "✓ No old CH history files to clean up"
+          fi
+
+      - name: Cleanup CH temporary file
+        if: steps.compare_ch.outputs.new_data == 'false'
+        run: |
+          if [ -f public/data/ch/marketdata_new.json ]; then
+            rm -f public/data/ch/marketdata_new.json
+            echo "🧹 Cleaned up CH temporary file (no new data)"
+          fi
+
       # ─── Commit ───────────────────────────────────────────────────────────────
 
       - name: Commit changes
-        if: steps.compare.outputs.new_data == 'true' || steps.compare_nl.outputs.new_data == 'true'
+        if: >
+          steps.compare.outputs.new_data == 'true' ||
+          steps.compare_nl.outputs.new_data == 'true' ||
+          steps.compare_at.outputs.new_data == 'true' ||
+          steps.compare_ch.outputs.new_data == 'true'
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
@@ -645,6 +1164,20 @@ jobs:
             git add -A public/data/nl/history/
           fi
 
+          # Stage AT files if updated
+          if [ "${{ steps.compare_at.outputs.new_data }}" = "true" ]; then
+            git add public/data/at/marketdata.json
+            git add -A public/data/at/archive/
+            git add -A public/data/at/history/
+          fi
+
+          # Stage CH files if updated
+          if [ "${{ steps.compare_ch.outputs.new_data }}" = "true" ]; then
+            git add public/data/ch/marketdata.json
+            git add -A public/data/ch/archive/
+            git add -A public/data/ch/history/
+          fi
+
           TIMESTAMP=$(date -u +"%Y-%m-%dT%H UTC")
 
           # Build commit message listing updated countries and their sources
@@ -657,6 +1190,14 @@ jobs:
             NL_SOURCE=$(node -e 'console.log(JSON.parse(require("fs").readFileSync("public/data/nl/marketdata.json", "utf8")).source)')
             PARTS="${PARTS:+$PARTS, }NL: $NL_SOURCE"
           fi
+          if [ "${{ steps.compare_at.outputs.new_data }}" = "true" ]; then
+            AT_SOURCE=$(node -e 'console.log(JSON.parse(require("fs").readFileSync("public/data/at/marketdata.json", "utf8")).source)')
+            PARTS="${PARTS:+$PARTS, }AT: $AT_SOURCE"
+          fi
+          if [ "${{ steps.compare_ch.outputs.new_data }}" = "true" ]; then
+            CH_SOURCE=$(node -e 'console.log(JSON.parse(require("fs").readFileSync("public/data/ch/marketdata.json", "utf8")).source)')
+            PARTS="${PARTS:+$PARTS, }CH: $CH_SOURCE"
+          fi
 
           git commit -m "Update marketdata.json ($PARTS @ $TIMESTAMP)"
           git push
@@ -665,7 +1206,11 @@ jobs:
           echo "🚀 Deployment will be triggered automatically by push to main"
 
       - name: Summary (new data)
-        if: steps.compare.outputs.new_data == 'true' || steps.compare_nl.outputs.new_data == 'true'
+        if: >
+          steps.compare.outputs.new_data == 'true' ||
+          steps.compare_nl.outputs.new_data == 'true' ||
+          steps.compare_at.outputs.new_data == 'true' ||
+          steps.compare_ch.outputs.new_data == 'true'
         run: |
           echo "✅ Market data updated successfully!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -677,11 +1222,23 @@ jobs:
             echo "🇳🇱 **NL Source:** $(node -e 'console.log(JSON.parse(require("fs").readFileSync("public/data/nl/marketdata.json", "utf8")).source)')" >> $GITHUB_STEP_SUMMARY
             echo "📈 **NL Data points:** $(node -e 'console.log(JSON.parse(require("fs").readFileSync("public/data/nl/marketdata.json", "utf8")).data.length)')" >> $GITHUB_STEP_SUMMARY
           fi
+          if [ "${{ steps.compare_at.outputs.new_data }}" = "true" ]; then
+            echo "🇦🇹 **AT Source:** $(node -e 'console.log(JSON.parse(require("fs").readFileSync("public/data/at/marketdata.json", "utf8")).source)')" >> $GITHUB_STEP_SUMMARY
+            echo "📈 **AT Data points:** $(node -e 'console.log(JSON.parse(require("fs").readFileSync("public/data/at/marketdata.json", "utf8")).data.length)')" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "${{ steps.compare_ch.outputs.new_data }}" = "true" ]; then
+            echo "🇨🇭 **CH Source:** $(node -e 'console.log(JSON.parse(require("fs").readFileSync("public/data/ch/marketdata.json", "utf8")).source)')" >> $GITHUB_STEP_SUMMARY
+            echo "📈 **CH Data points:** $(node -e 'console.log(JSON.parse(require("fs").readFileSync("public/data/ch/marketdata.json", "utf8")).data.length)')" >> $GITHUB_STEP_SUMMARY
+          fi
           echo "⏰ **Updated at:** $(date -u +"%Y-%m-%d %H:%M:%S UTC")" >> $GITHUB_STEP_SUMMARY
           echo "🚀 **Deployment:** Automatically triggered by push to main" >> $GITHUB_STEP_SUMMARY
 
       - name: Summary (no new data)
-        if: steps.compare.outputs.new_data == 'false' && steps.compare_nl.outputs.new_data == 'false'
+        if: >
+          steps.compare.outputs.new_data == 'false' &&
+          steps.compare_nl.outputs.new_data == 'false' &&
+          steps.compare_at.outputs.new_data == 'false' &&
+          steps.compare_ch.outputs.new_data == 'false'
         run: |
           echo "ℹ️ No new data available – keeping existing marketdata files" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/components/customize/CountrySection.tsx
+++ b/components/customize/CountrySection.tsx
@@ -8,8 +8,9 @@ import { COUNTRIES, COUNTRY_CODES } from '../../utils/countries';
 
 /**
  * Country selection section for the Customize menu.
+ * Renders a vertical list so any number of countries fits without overflow.
  * Switches the active country (national data only). Determines data
- * availability and whether the regional/PLZ UI is shown (Issue #356).
+ * availability and whether the regional/PLZ UI is shown (Issue #356, #368).
  */
 export function CountrySection() {
   const { t } = useLanguageContext();
@@ -21,32 +22,40 @@ export function CountrySection() {
   return (
     <View style={styles.menuSection}>
       <Text style={[styles.sectionTitle, { color: colors.textSecondary }]}>{t.country}</Text>
-      <View style={styles.countryToggle}>
-        {COUNTRY_CODES.map(code => {
+      <View style={[styles.countryList, { borderColor: colors.gridLine }]}>
+        {COUNTRY_CODES.map((code, index) => {
           const config = COUNTRIES[code];
           const active = country === code;
+          const isLast = index === COUNTRY_CODES.length - 1;
           return (
             <TouchableOpacity
               key={code}
               style={[
-                styles.countryButton,
-                active && styles.countryButtonActive,
-                { backgroundColor: active ? colors.primary : colors.gridLine },
+                styles.countryRow,
+                !isLast && {
+                  borderBottomWidth: StyleSheet.hairlineWidth,
+                  borderBottomColor: colors.gridLine,
+                },
               ]}
               onPress={() => setCountry(code)}
-              accessibilityRole="button"
+              accessibilityRole="radio"
               accessibilityState={{ selected: active }}
             >
-              <Text
-                style={{
-                  color: active ? '#fff' : colors.text,
-                  fontSize: 12,
-                  fontWeight: '600',
-                }}
-              >
-                {config.flag} {t[config.translationKey]}
-                {config.beta ? ` ${t.countryBeta}` : ''}
+              <Text style={styles.flag}>{config.flag}</Text>
+              <Text style={[styles.countryName, { color: colors.text }]}>
+                {t[config.translationKey]}
+                {config.beta ? (
+                  <Text style={[styles.betaBadge, { color: colors.textSecondary }]}>
+                    {' '}
+                    {t.countryBeta}
+                  </Text>
+                ) : null}
               </Text>
+              {active && (
+                <View style={[styles.checkmark, { backgroundColor: colors.primary }]}>
+                  <Text style={styles.checkmarkText}>✓</Text>
+                </View>
+              )}
             </TouchableOpacity>
           );
         })}
@@ -65,23 +74,42 @@ const styles = StyleSheet.create({
     textTransform: 'uppercase',
     letterSpacing: 0.5,
   },
-  countryToggle: {
-    flexDirection: 'row',
-    gap: 8,
+  countryList: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderRadius: 10,
+    overflow: 'hidden',
   },
-  countryButton: {
-    flex: 1,
+  countryRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
     paddingVertical: 12,
-    paddingHorizontal: 16,
-    borderRadius: 8,
+    paddingHorizontal: 14,
+    gap: 10,
+  },
+  flag: {
+    fontSize: 20,
+    lineHeight: 24,
+  },
+  countryName: {
+    flex: 1,
+    fontSize: 15,
+    fontWeight: '500',
+  },
+  betaBadge: {
+    fontSize: 12,
+    fontWeight: '400',
+  },
+  checkmark: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
     alignItems: 'center',
     justifyContent: 'center',
   },
-  countryButtonActive: {
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.1,
-    shadowRadius: 4,
-    elevation: 2,
+  checkmarkText: {
+    color: '#fff',
+    fontSize: 13,
+    fontWeight: '700',
+    lineHeight: 16,
   },
 });

--- a/utils/countries.ts
+++ b/utils/countries.ts
@@ -13,7 +13,7 @@
  * clients; new countries live under `data/<code>/`.
  */
 
-export type CountryCode = 'de' | 'nl';
+export type CountryCode = 'de' | 'nl' | 'at' | 'ch';
 
 export interface CountryConfig {
   /** Internal country code (matches storage namespace + data folder). */
@@ -23,7 +23,7 @@ export interface CountryConfig {
   /** Flag emoji for compact UI display. */
   flag: string;
   /** translations key for the human-readable country name (must exist in EN+DE). */
-  translationKey: 'countryGermany' | 'countryNetherlands';
+  translationKey: 'countryGermany' | 'countryNetherlands' | 'countryAustria' | 'countrySwitzerland';
   /** Whether the country is still rolling out (shows a BETA badge). */
   beta: boolean;
   /** IANA timezone used for day boundaries in the historical store. */
@@ -71,6 +71,32 @@ export const COUNTRIES: Record<CountryCode, CountryConfig> = {
     hasRegionalData: false,
     marketDataPath: 'data/nl/marketdata.json',
     historyPathPrefix: 'data/nl/history/',
+    defaultGridFeesCentPerKwh: 20,
+  },
+  at: {
+    code: 'at',
+    energyChartsCountry: 'at',
+    flag: '🇦🇹',
+    translationKey: 'countryAustria',
+    beta: true,
+    timezone: 'Europe/Vienna',
+    currency: 'EUR',
+    hasRegionalData: false,
+    marketDataPath: 'data/at/marketdata.json',
+    historyPathPrefix: 'data/at/history/',
+    defaultGridFeesCentPerKwh: 20,
+  },
+  ch: {
+    code: 'ch',
+    energyChartsCountry: 'ch',
+    flag: '🇨🇭',
+    translationKey: 'countrySwitzerland',
+    beta: true,
+    timezone: 'Europe/Zurich',
+    currency: 'EUR',
+    hasRegionalData: false,
+    marketDataPath: 'data/ch/marketdata.json',
+    historyPathPrefix: 'data/ch/history/',
     defaultGridFeesCentPerKwh: 20,
   },
 };

--- a/utils/translations.ts
+++ b/utils/translations.ts
@@ -15,6 +15,8 @@ export const translations = {
     country: 'COUNTRY',
     countryGermany: 'Germany',
     countryNetherlands: 'Netherlands',
+    countryAustria: 'Austria',
+    countrySwitzerland: 'Switzerland',
     countryBeta: '(BETA)',
     // Region Section
     region: 'REGION (BETA)',
@@ -173,6 +175,8 @@ export const translations = {
     country: 'LAND',
     countryGermany: 'Deutschland',
     countryNetherlands: 'Niederlande',
+    countryAustria: 'Österreich',
+    countrySwitzerland: 'Schweiz',
     countryBeta: '(BETA)',
     // Region Section
     region: 'REGION (BETA)',


### PR DESCRIPTION
## Zusammenfassung

Phase 1 von Issue #368: Österreich (AT) und Schweiz (CH) als BETA-Länder in der App und Datenpipeline.

## Änderungen

### Daten-Pipeline (`fetch.yml`)
- **AT-Block** (Energy Charts only, kein aWATTar): Fetch → Process → Validate → Archive + History → Cleanup
- **CH-Block** (Energy Charts only): Fetch → Process → Validate → Archive + History → Cleanup
- `sleep 2` zwischen den Länder-Blöcken als Rate-Limit-Schutz (beobachtet bei schnellen Burst-Requests)
- Commit-Schritt und Summary um AT / CH erweitert; Commit-Message zeigt welche Länder aktualisiert wurden
- Datenpfade: `public/data/at/` und `public/data/ch/` (analog zu NL)

### Country-Registry (`utils/countries.ts`)
- `CountryCode` um `'at'` und `'ch'` erweitert
- AT: Zeitzone `Europe/Vienna`, EPEX-Zone, `hasRegionalData: false`, BETA
- CH: Zeitzone `Europe/Zurich`, EPEX-Zone, `hasRegionalData: false`, BETA
- `translationKey` Typ um `countryAustria` / `countrySwitzerland` erweitert

### Übersetzungen (`utils/translations.ts`)
- `countryAustria`: "Austria" / "Österreich"
- `countrySwitzerland`: "Switzerland" / "Schweiz"

### UI (`components/customize/CountrySection.tsx`)
- **Toggle → vertikale Liste**: Skaliert auf beliebig viele Länder ohne Overflow
- Jede Zeile: Flag-Emoji + Landesname + BETA-Badge (wenn zutreffend) + Checkmark rechts beim aktiven Land
- Trennlinien zwischen den Einträgen (`StyleSheet.hairlineWidth`)
- `accessibilityRole="radio"` für korrekte Semantik

## Test-Plan

- [x] TypeScript: keine neuen Fehler (`tsc --noEmit`)
- [x] Alle 283 Tests grün (`npm test`)
- [ ] Manuell: Länder in Customize-Modal wechseln (DE → AT → CH → NL → DE)
- [ ] Manuell: PLZ-Feld verschwindet bei AT/CH (kein `hasRegionalData`)
- [ ] CI: fetch.yml `workflow_dispatch` triggern und prüfen ob AT + CH Daten erscheinen

## Nicht in diesem PR

- aWATTar.at-Supplement für AT (separates Issue – erst wenn EC-Daten für AT bestätigt sind)
- Flag-Chip im Main-Header (nur sinnvoll wenn Länder aus dem Header schnell erreichbar sein müssen – könnte in Follow-up kommen)

Closes Teil von #368 (Phase 1)