### PR TITLE
Fix #355: Chart-Zoom &amp; Titel-Überlauf, Fix #334: Pre-Aggregierung für 30d-Verlauf

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -259,6 +259,34 @@ jobs:
             } else {
               console.log("✓ History file already exists: " + yesterdayStr + ".json");
             }
+
+            // Pre-aggregated hourly variant (~75% smaller) for long-range views (#334)
+            const hourlyFile = "public/data/history/" + yesterdayStr + "-hourly.json";
+            if (!fs.existsSync(hourlyFile)) {
+              const avg = values => values.length ? values.reduce((s, v) => s + v, 0) / values.length : null;
+              const buckets = new Map();
+              for (const item of yesterdayData) {
+                const bucketTs = Math.floor(item.start_timestamp / 3600000) * 3600000;
+                (buckets.get(bucketTs) || buckets.set(bucketTs, []).get(bucketTs)).push(item);
+              }
+              const hourlyData = Array.from(buckets.entries())
+                .sort(([a], [b]) => a - b)
+                .map(([bucketTs, items]) => ({
+                  start_timestamp: bucketTs,
+                  end_timestamp: bucketTs + 3600000,
+                  marketprice: avg(items.filter(i => i.marketprice != null).map(i => i.marketprice)),
+                  renewable_share: avg(items.filter(i => i.renewable_share != null).map(i => i.renewable_share)),
+                  unit: items[0].unit,
+                  interpolated: items.some(i => i.interpolated),
+                }));
+              fs.writeFileSync(hourlyFile, JSON.stringify({
+                date: yesterdayStr,
+                source: data.source,
+                resolution: "hourly",
+                data: hourlyData
+              }, null, 2));
+              console.log("✓ Created hourly history file: " + yesterdayStr + "-hourly.json (" + hourlyData.length + " points)");
+            }
           } else {
             console.log("⚠️ Incomplete data for " + yesterdayStr + " (" + yesterdayData.length + "/96 points) - skipping");
           }
@@ -561,6 +589,34 @@ jobs:
             } else {
               console.log("✓ NL history file already exists: " + yesterdayStr + ".json");
             }
+
+            // Pre-aggregated hourly variant (~75% smaller) for long-range views (#334)
+            const hourlyFile = "public/data/nl/history/" + yesterdayStr + "-hourly.json";
+            if (!fs.existsSync(hourlyFile)) {
+              const avg = values => values.length ? values.reduce((s, v) => s + v, 0) / values.length : null;
+              const buckets = new Map();
+              for (const item of yesterdayData) {
+                const bucketTs = Math.floor(item.start_timestamp / 3600000) * 3600000;
+                (buckets.get(bucketTs) || buckets.set(bucketTs, []).get(bucketTs)).push(item);
+              }
+              const hourlyData = Array.from(buckets.entries())
+                .sort(([a], [b]) => a - b)
+                .map(([bucketTs, items]) => ({
+                  start_timestamp: bucketTs,
+                  end_timestamp: bucketTs + 3600000,
+                  marketprice: avg(items.filter(i => i.marketprice != null).map(i => i.marketprice)),
+                  renewable_share: avg(items.filter(i => i.renewable_share != null).map(i => i.renewable_share)),
+                  unit: items[0].unit,
+                  interpolated: items.some(i => i.interpolated),
+                }));
+              fs.writeFileSync(hourlyFile, JSON.stringify({
+                date: yesterdayStr,
+                source: data.source,
+                resolution: "hourly",
+                data: hourlyData
+              }, null, 2));
+              console.log("✓ Created NL hourly history file: " + yesterdayStr + "-hourly.json (" + hourlyData.length + " points)");
+            }
           } else {
             console.log("⚠️ Incomplete NL data for " + yesterdayStr + " (" + yesterdayData.length + "/96 points) - skipping");
           }
@@ -835,6 +891,34 @@ jobs:
             } else {
               console.log("✓ AT history file already exists: " + yesterdayStr + ".json");
             }
+
+            // Pre-aggregated hourly variant (~75% smaller) for long-range views (#334)
+            const hourlyFile = "public/data/at/history/" + yesterdayStr + "-hourly.json";
+            if (!fs.existsSync(hourlyFile)) {
+              const avg = values => values.length ? values.reduce((s, v) => s + v, 0) / values.length : null;
+              const buckets = new Map();
+              for (const item of yesterdayData) {
+                const bucketTs = Math.floor(item.start_timestamp / 3600000) * 3600000;
+                (buckets.get(bucketTs) || buckets.set(bucketTs, []).get(bucketTs)).push(item);
+              }
+              const hourlyData = Array.from(buckets.entries())
+                .sort(([a], [b]) => a - b)
+                .map(([bucketTs, items]) => ({
+                  start_timestamp: bucketTs,
+                  end_timestamp: bucketTs + 3600000,
+                  marketprice: avg(items.filter(i => i.marketprice != null).map(i => i.marketprice)),
+                  renewable_share: avg(items.filter(i => i.renewable_share != null).map(i => i.renewable_share)),
+                  unit: items[0].unit,
+                  interpolated: items.some(i => i.interpolated),
+                }));
+              fs.writeFileSync(hourlyFile, JSON.stringify({
+                date: yesterdayStr,
+                source: data.source,
+                resolution: "hourly",
+                data: hourlyData
+              }, null, 2));
+              console.log("✓ Created AT hourly history file: " + yesterdayStr + "-hourly.json (" + hourlyData.length + " points)");
+            }
           } else {
             console.log("⚠️ Incomplete AT data for " + yesterdayStr + " (" + yesterdayData.length + "/96 points) - skipping");
           }
@@ -1091,6 +1175,34 @@ jobs:
               console.log("✓ Created CH history file: " + yesterdayStr + ".json (" + yesterdayData.length + " points)");
             } else {
               console.log("✓ CH history file already exists: " + yesterdayStr + ".json");
+            }
+
+            // Pre-aggregated hourly variant (~75% smaller) for long-range views (#334)
+            const hourlyFile = "public/data/ch/history/" + yesterdayStr + "-hourly.json";
+            if (!fs.existsSync(hourlyFile)) {
+              const avg = values => values.length ? values.reduce((s, v) => s + v, 0) / values.length : null;
+              const buckets = new Map();
+              for (const item of yesterdayData) {
+                const bucketTs = Math.floor(item.start_timestamp / 3600000) * 3600000;
+                (buckets.get(bucketTs) || buckets.set(bucketTs, []).get(bucketTs)).push(item);
+              }
+              const hourlyData = Array.from(buckets.entries())
+                .sort(([a], [b]) => a - b)
+                .map(([bucketTs, items]) => ({
+                  start_timestamp: bucketTs,
+                  end_timestamp: bucketTs + 3600000,
+                  marketprice: avg(items.filter(i => i.marketprice != null).map(i => i.marketprice)),
+                  renewable_share: avg(items.filter(i => i.renewable_share != null).map(i => i.renewable_share)),
+                  unit: items[0].unit,
+                  interpolated: items.some(i => i.interpolated),
+                }));
+              fs.writeFileSync(hourlyFile, JSON.stringify({
+                date: yesterdayStr,
+                source: data.source,
+                resolution: "hourly",
+                data: hourlyData
+              }, null, 2));
+              console.log("✓ Created CH hourly history file: " + yesterdayStr + "-hourly.json (" + hourlyData.length + " points)");
             }
           } else {
             console.log("⚠️ Incomplete CH data for " + yesterdayStr + " (" + yesterdayData.length + "/96 points) - skipping");
@@ -1349,6 +1461,34 @@ jobs:
             } else {
               console.log("✓ FR history file already exists: " + yesterdayStr + ".json");
             }
+
+            // Pre-aggregated hourly variant (~75% smaller) for long-range views (#334)
+            const hourlyFile = "public/data/fr/history/" + yesterdayStr + "-hourly.json";
+            if (!fs.existsSync(hourlyFile)) {
+              const avg = values => values.length ? values.reduce((s, v) => s + v, 0) / values.length : null;
+              const buckets = new Map();
+              for (const item of yesterdayData) {
+                const bucketTs = Math.floor(item.start_timestamp / 3600000) * 3600000;
+                (buckets.get(bucketTs) || buckets.set(bucketTs, []).get(bucketTs)).push(item);
+              }
+              const hourlyData = Array.from(buckets.entries())
+                .sort(([a], [b]) => a - b)
+                .map(([bucketTs, items]) => ({
+                  start_timestamp: bucketTs,
+                  end_timestamp: bucketTs + 3600000,
+                  marketprice: avg(items.filter(i => i.marketprice != null).map(i => i.marketprice)),
+                  renewable_share: avg(items.filter(i => i.renewable_share != null).map(i => i.renewable_share)),
+                  unit: items[0].unit,
+                  interpolated: items.some(i => i.interpolated),
+                }));
+              fs.writeFileSync(hourlyFile, JSON.stringify({
+                date: yesterdayStr,
+                source: data.source,
+                resolution: "hourly",
+                data: hourlyData
+              }, null, 2));
+              console.log("✓ Created FR hourly history file: " + yesterdayStr + "-hourly.json (" + hourlyData.length + " points)");
+            }
           } else {
             console.log("⚠️ Incomplete FR data for " + yesterdayStr + " (" + yesterdayData.length + "/96 points) - skipping");
           }
@@ -1606,6 +1746,34 @@ jobs:
             } else {
               console.log("✓ BE history file already exists: " + yesterdayStr + ".json");
             }
+
+            // Pre-aggregated hourly variant (~75% smaller) for long-range views (#334)
+            const hourlyFile = "public/data/be/history/" + yesterdayStr + "-hourly.json";
+            if (!fs.existsSync(hourlyFile)) {
+              const avg = values => values.length ? values.reduce((s, v) => s + v, 0) / values.length : null;
+              const buckets = new Map();
+              for (const item of yesterdayData) {
+                const bucketTs = Math.floor(item.start_timestamp / 3600000) * 3600000;
+                (buckets.get(bucketTs) || buckets.set(bucketTs, []).get(bucketTs)).push(item);
+              }
+              const hourlyData = Array.from(buckets.entries())
+                .sort(([a], [b]) => a - b)
+                .map(([bucketTs, items]) => ({
+                  start_timestamp: bucketTs,
+                  end_timestamp: bucketTs + 3600000,
+                  marketprice: avg(items.filter(i => i.marketprice != null).map(i => i.marketprice)),
+                  renewable_share: avg(items.filter(i => i.renewable_share != null).map(i => i.renewable_share)),
+                  unit: items[0].unit,
+                  interpolated: items.some(i => i.interpolated),
+                }));
+              fs.writeFileSync(hourlyFile, JSON.stringify({
+                date: yesterdayStr,
+                source: data.source,
+                resolution: "hourly",
+                data: hourlyData
+              }, null, 2));
+              console.log("✓ Created BE hourly history file: " + yesterdayStr + "-hourly.json (" + hourlyData.length + " points)");
+            }
           } else {
             console.log("⚠️ Incomplete BE data for " + yesterdayStr + " (" + yesterdayData.length + "/96 points) - skipping");
           }
@@ -1862,6 +2030,34 @@ jobs:
               console.log("✓ Created DK history file: " + yesterdayStr + ".json (" + yesterdayData.length + " points)");
             } else {
               console.log("✓ DK history file already exists: " + yesterdayStr + ".json");
+            }
+
+            // Pre-aggregated hourly variant (~75% smaller) for long-range views (#334)
+            const hourlyFile = "public/data/dk/history/" + yesterdayStr + "-hourly.json";
+            if (!fs.existsSync(hourlyFile)) {
+              const avg = values => values.length ? values.reduce((s, v) => s + v, 0) / values.length : null;
+              const buckets = new Map();
+              for (const item of yesterdayData) {
+                const bucketTs = Math.floor(item.start_timestamp / 3600000) * 3600000;
+                (buckets.get(bucketTs) || buckets.set(bucketTs, []).get(bucketTs)).push(item);
+              }
+              const hourlyData = Array.from(buckets.entries())
+                .sort(([a], [b]) => a - b)
+                .map(([bucketTs, items]) => ({
+                  start_timestamp: bucketTs,
+                  end_timestamp: bucketTs + 3600000,
+                  marketprice: avg(items.filter(i => i.marketprice != null).map(i => i.marketprice)),
+                  renewable_share: avg(items.filter(i => i.renewable_share != null).map(i => i.renewable_share)),
+                  unit: items[0].unit,
+                  interpolated: items.some(i => i.interpolated),
+                }));
+              fs.writeFileSync(hourlyFile, JSON.stringify({
+                date: yesterdayStr,
+                source: data.source,
+                resolution: "hourly",
+                data: hourlyData
+              }, null, 2));
+              console.log("✓ Created DK hourly history file: " + yesterdayStr + "-hourly.json (" + hourlyData.length + " points)");
             }
           } else {
             console.log("⚠️ Incomplete DK data for " + yesterdayStr + " (" + yesterdayData.length + "/96 points) - skipping");

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- **Chart-Zoom (Issue #355):** `PriceBarChart`, `RenewableBarChart` und `CorrelationScatterChart` (inkl. Detail-Modal `ChartDetailView`) unterstützen jetzt Pinch-to-Zoom (mobil) bzw. Scroll-to-Zoom (Web), um einzelne Stunden bei 48h-/7d-Ansichten besser erkennbar zu machen. Neuer gemeinsamer Hook `useChartZoom` (`components/charts/shared/`); die Y-Achsen-Beschriftung bleibt beim Scrollen fixiert, ein Reset-Badge erscheint bei aktivem Zoom.
+
 ### Fixed
+- **Titel-Überlauf bei „Anteil erneuerbare Energien..." (Issue #355):** Chart-Titel in `PriceBarChart`, `RenewableBarChart` und `CorrelationScatterChart` brechen jetzt bei Bedarf zweizeilig um (`numberOfLines={2}`, `flex: 1`) statt auf kleinen Bildschirmen abgeschnitten zu werden.
+
+### Performance
+- **Pre-Aggregierung für die 30-Tage-Ansicht (Issue #334):** Die tägliche History-Pipeline (`fetch.yml`, alle Länder) erzeugt jetzt zusätzlich eine stündlich vorab-aggregierte `<date>-hourly.json` Variante (~75% kleiner) pro Tag. `historicalDataStore.getRange()` lädt für die 30-Tage-Ansicht in `HistoricalDataView` bevorzugt diese Variante nach (mit automatischem Fallback auf die volle Auflösung, falls sie fehlt) – deutlich weniger Downloadvolumen, da diese Ansicht ohnehin clientseitig auf Tages-Buckets aggregiert dargestellt wird.
 - **Potenzielle App-Abstürze (Issue #376):** Zwei verifizierte Absturzquellen behoben, die zum "App ist im Mai zweimal abgestürzt"-Report im Play Store passen (kein Stacktrace verfügbar):
   - **`Math.min(...array)`/`Math.max(...array)`-Spread** in `utils/metrics.ts`, `App.tsx`, `utils/chartUtils.ts` und den drei Chart-Komponenten (`PriceBarChart`, `RenewableBarChart`, `CorrelationScatterChart`) durch schleifenbasierte `arrayMin`/`arrayMax`-Helfer (`utils/mathUtils.ts`) ersetzt. Der Spread-Ansatz kann bei ungewöhnlich großen Arrays (z.B. durch einen Datenmerge-Bug oder lange Verlaufs-Zeiträume) einen `RangeError: Maximum call stack size exceeded` werfen – die neuen Helfer haben keine Obergrenze.
   - **`react-native-worklets`-Versionskonflikt:** `package.json` pinnte `0.7.2`, während `expo-modules-core` (gebündelt mit Expo 55) `^0.7.4 || ^0.8.0` verlangt – npm löste dadurch zwei divergierende native Kopien der Bibliothek auf (root `0.7.2` vs. verschachtelt `0.8.1` unter `expo`). Auf `0.8.1` vereinheitlicht, sodass nur noch eine native Modul-Kopie existiert.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,17 @@ Validation rules enforced by Husky:
    - Performance-optimized with useMemo/useCallback/React.memo
    - Responsive design via `useChartDimensions()` hook
    - Touch/hover interactions (platform-aware)
+   - **Pinch/scroll zoom (Issue #355, PR #380):** all three charts (+ `ChartDetailView`) get zoom
+     via the shared `useChartZoom(viewportWidth)` hook (`components/charts/shared/useChartZoom.ts`).
+     `contentWidth` replaces `chartWidth` for all internal x-position math and is wrapped in a
+     horizontal `ScrollView`; Y-axis labels are deliberately rendered *outside* that ScrollView
+     (pinned overlay) so they don't scroll away. Web zooms via `onWheel`, native via a 2-touch
+     `PanResponder` (no `react-native-gesture-handler` dependency added). `ZoomResetBadge.tsx`
+     shows a ⟲ reset control when `isZoomed`. Tooltip `x` must go through `toViewportX()` before
+     `getTooltipLeft()` so it stays aligned with the current scroll offset.
+   - **Title overflow (Issue #355, PR #380):** title wrapper needs `flex: 1` + the `<Text>` needs
+     `numberOfLines={2}`/`ellipsizeMode="tail"` — otherwise long titles (e.g. regional renewable
+     title) clip on small screens instead of wrapping.
 
 5. **Historical Data (`services/historicalDataStore.ts`) – Issues #307/#1/#3 (PR #309):**
    - **Device cache is the primary source.** Every successful national fetch in
@@ -174,9 +185,17 @@ Validation rules enforced by Husky:
    - **MB-based eviction:** user sets `historyCacheLimitMb` (5/10/25/50; default 10) in the
      Customize modal (`HistoryCacheSection`); `App.tsx` forwards it via
      `energyDataManager.setHistoryLimitBytes`; `enforceLimit` drops oldest days over budget.
-   - **Server fallback:** `getRange(from, to, allowServerFallback=true)` loads missing *past*
-     days from `data/history/<date>.json` (validated via `apiValidation`) into the cache;
-     404/errors ignored; `serverFetchAttempted` avoids repeat misses per session.
+   - **Server fallback:** `getRange(from, to, allowServerFallback=true, resolution='raw')` loads
+     missing *past* days from `data/history/<date>.json` (validated via `apiValidation`) into the
+     cache; 404/errors ignored; `serverFetchAttempted` avoids repeat misses per session.
+   - **Hourly pre-aggregation (Issue #334, PR #380):** `resolution: 'hourly'` fetches the smaller
+     pre-aggregated `data/history/<date>-hourly.json` instead (~75% smaller, ~24 pts/day vs. 96),
+     generated per-day in `fetch.yml` (all countries) right after the raw history file. Falls back
+     to the raw file automatically if the hourly variant 404s (e.g. older dates predating this
+     feature). `HistoricalDataView` passes `'hourly'` only for the 30d range (already
+     daily-bucketed client-side via `dataAggregation.ts`); 24h/48h/7d stay `'raw'`. A day already
+     cached (e.g. from a live snapshot) is never re-fetched, so it keeps whatever resolution it
+     has — don't assume every cached day is full 15-min resolution when reasoning about stats.
    - **UI:** `HistoricalDataView` (Settings → "Verlauf") = range selector 24h/48h/7d/30d (#1),
      charts aggregated via `dataAggregation.ts` (15min/hourly/daily), stats via
      `historicalStats.ts` (#3). The live main screen is intentionally unchanged.
@@ -321,6 +340,8 @@ components/
 │       ├── ChartCard.tsx         # Card wrapper with shadow + fade-in animation
 │       ├── ChartTooltip.tsx      # Tooltip with boundary clamping + scale/fade animation
 │       ├── NowMarker.tsx         # "Jetzt" time marker (line + label)
+│       ├── useChartZoom.ts       # Pinch/scroll zoom hook (#355)
+│       ├── ZoomResetBadge.tsx    # ⟲ reset control shown while zoomed (#355)
 │       └── index.ts              # Barrel exports
 ├── settings/
 │   ├── AppearanceSection.tsx     # Theme pill selector with spring animation

--- a/components/HistoricalDataView.tsx
+++ b/components/HistoricalDataView.tsx
@@ -91,10 +91,14 @@ export function HistoricalDataView({
 
       // Aktuelle Periode (Cache + Server-Fallback) und Vorperiode parallel laden,
       // aus dem länder-namespaced Store des aktiven Landes.
+      // 30d nutzt die vorab-aggregierte stündliche Server-Variante für neu
+      // nachgeladene Tage, da dieser Bereich ohnehin auf Tages-Buckets
+      // aggregiert dargestellt wird (#334) – spart Downloadvolumen.
+      const resolution = timeRange === '30d' ? 'hourly' : 'raw';
       const store = historicalDataStoreForCountry(country);
       const [historical, previousHistorical] = await Promise.all([
-        store.getRange(from, now),
-        store.getRange(prevFrom, from),
+        store.getRange(from, now, true, resolution),
+        store.getRange(prevFrom, from, true, resolution),
       ]);
       if (cancelled) return;
 

--- a/components/charts/CorrelationScatterChart.tsx
+++ b/components/charts/CorrelationScatterChart.tsx
@@ -1,11 +1,19 @@
 import React, { useState, useMemo } from 'react';
-import { View, Text, Platform } from 'react-native';
+import { View, Text, Platform, ScrollView } from 'react-native';
 import Svg, { Circle, Line } from 'react-native-svg';
 import type { ThemeColors } from '../../utils/theme';
 import { getYAxisLabelStyle } from '../../utils/chartHelpers';
 import { useChartDimensions } from '../../utils/chartUtils';
 import { arrayMin, arrayMax } from '../../utils/mathUtils';
-import { ChartGrid, ChartCard, ChartTooltip, getTooltipLeft } from './shared';
+import { useLanguageContext } from '../../context/LanguageContext';
+import {
+  ChartGrid,
+  ChartCard,
+  ChartTooltip,
+  getTooltipLeft,
+  useChartZoom,
+  ZoomResetBadge,
+} from './shared';
 
 interface CorrelationScatterChartProps {
   title: string;
@@ -47,10 +55,11 @@ function CorrelationScatterChartComponent({
   accentColor,
 }: CorrelationScatterChartProps) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const { t } = useLanguageContext();
 
   // Use centralized chart dimensions hook
   const {
-    chartWidth,
+    chartWidth: viewportWidth,
     chartHeight,
     leftPadding,
     padding,
@@ -61,6 +70,18 @@ function CorrelationScatterChartComponent({
     isPhone,
     isLandscape,
   } = useChartDimensions();
+
+  // Pinch (mobile) / scroll (web) zoom (#355) — contentWidth replaces the static
+  // chartWidth for all internal x-position math below.
+  const {
+    contentWidth: chartWidth,
+    isZoomed,
+    resetZoom,
+    scrollRef,
+    scrollViewProps,
+    gestureContainerProps,
+    toViewportX,
+  } = useChartZoom(viewportWidth);
 
   // Performance: Memoize expensive data calculations (filtering, regression, ranges)
   const chartCalcs = useMemo(() => {
@@ -213,7 +234,7 @@ function CorrelationScatterChartComponent({
             leftPadding +
             (((item.renewableShare ?? 0) - minRenewable) / renewableRange) *
               (chartWidth - leftPadding - rightPadding);
-          const tooltipLeft = getTooltipLeft(x, 120, chartWidth);
+          const tooltipLeft = getTooltipLeft(toViewportX(x), 120, viewportWidth);
 
           return (
             <ChartTooltip
@@ -241,7 +262,7 @@ function CorrelationScatterChartComponent({
           marginBottom: 0,
         }}
       >
-        <View>
+        <View style={{ flex: 1, marginRight: 8 }}>
           <Text
             style={{
               fontSize: isPhone ? 16 : 18,
@@ -249,6 +270,8 @@ function CorrelationScatterChartComponent({
               marginBottom: 0,
               color: textColor,
             }}
+            numberOfLines={2}
+            ellipsizeMode="tail"
           >
             {title}
           </Text>
@@ -300,95 +323,143 @@ function CorrelationScatterChartComponent({
           </View>
         )}
       </View>
-      <View style={{ height: chartHeight, width: chartWidth }}>
-        <ChartGrid
-          chartWidth={chartWidth}
-          chartHeight={chartHeight}
-          leftPadding={leftPadding}
-          rightPadding={rightPadding}
-          padding={padding}
-          bottomPadding={bottomPadding}
-          gridColor={gridColor}
-          verticalLines={5}
-        />
+      <View
+        style={{ height: chartHeight, width: viewportWidth, position: 'relative' }}
+        {...gestureContainerProps}
+      >
+        <ScrollView
+          ref={scrollRef}
+          {...scrollViewProps}
+          style={{ width: viewportWidth, height: chartHeight }}
+          contentContainerStyle={{ width: chartWidth, height: chartHeight }}
+        >
+          <View style={{ height: chartHeight, width: chartWidth }}>
+            <ChartGrid
+              chartWidth={chartWidth}
+              chartHeight={chartHeight}
+              leftPadding={leftPadding}
+              rightPadding={rightPadding}
+              padding={padding}
+              bottomPadding={bottomPadding}
+              gridColor={gridColor}
+              verticalLines={5}
+            />
 
-        {/* Scatter Points */}
-        <Svg width={chartWidth} height={chartHeight}>
-          {/* Trendlinie */}
-          <Line
-            x1={
-              leftPadding +
-              ((trendStartX - minRenewable) / renewableRange) *
-                (chartWidth - leftPadding - rightPadding)
-            }
-            y1={
-              chartHeight -
-              bottomPadding -
-              ((trendStartY - minPrice) / priceRange) * (chartHeight - padding - bottomPadding)
-            }
-            x2={
-              leftPadding +
-              ((trendEndX - minRenewable) / renewableRange) *
-                (chartWidth - leftPadding - rightPadding)
-            }
-            y2={
-              chartHeight -
-              bottomPadding -
-              ((trendEndY - minPrice) / priceRange) * (chartHeight - padding - bottomPadding)
-            }
-            stroke={textColor}
-            strokeWidth="2"
-            strokeDasharray="8,4"
-            opacity={0.4}
-          />
-
-          {scatterPoints.map(point => {
-            const isSelected = selectedIndex === point.index;
-
-            return (
-              <Circle
-                key={point.index}
-                cx={point.x}
-                cy={point.y}
-                r={isSelected ? 6 : 4}
-                fill={point.color}
-                opacity={isSelected ? 1.0 : 0.7}
-                stroke={isSelected ? '#999999' : 'none'}
-                strokeWidth={isSelected ? 2 : 0}
+            {/* Scatter Points */}
+            <Svg width={chartWidth} height={chartHeight}>
+              {/* Trendlinie */}
+              <Line
+                x1={
+                  leftPadding +
+                  ((trendStartX - minRenewable) / renewableRange) *
+                    (chartWidth - leftPadding - rightPadding)
+                }
+                y1={
+                  chartHeight -
+                  bottomPadding -
+                  ((trendStartY - minPrice) / priceRange) * (chartHeight - padding - bottomPadding)
+                }
+                x2={
+                  leftPadding +
+                  ((trendEndX - minRenewable) / renewableRange) *
+                    (chartWidth - leftPadding - rightPadding)
+                }
+                y2={
+                  chartHeight -
+                  bottomPadding -
+                  ((trendEndY - minPrice) / priceRange) * (chartHeight - padding - bottomPadding)
+                }
+                stroke={textColor}
+                strokeWidth="2"
+                strokeDasharray="8,4"
+                opacity={0.4}
               />
-            );
-          })}
-        </Svg>
 
-        {/* Invisible touch/hover areas for points - Using pre-calculated positions */}
-        {scatterPoints.map(point => {
-          const touchSize = 24;
+              {scatterPoints.map(point => {
+                const isSelected = selectedIndex === point.index;
 
-          return (
-            <View
-              key={`touch-${point.index}`}
+                return (
+                  <Circle
+                    key={point.index}
+                    cx={point.x}
+                    cy={point.y}
+                    r={isSelected ? 6 : 4}
+                    fill={point.color}
+                    opacity={isSelected ? 1.0 : 0.7}
+                    stroke={isSelected ? '#999999' : 'none'}
+                    strokeWidth={isSelected ? 2 : 0}
+                  />
+                );
+              })}
+            </Svg>
+
+            {/* Invisible touch/hover areas for points - Using pre-calculated positions */}
+            {scatterPoints.map(point => {
+              const touchSize = 24;
+
+              return (
+                <View
+                  key={`touch-${point.index}`}
+                  style={{
+                    position: 'absolute',
+                    left: point.x - touchSize / 2,
+                    top: point.y - touchSize / 2,
+                    width: touchSize,
+                    height: touchSize,
+                    zIndex: 10,
+                    cursor: Platform.OS === 'web' ? 'pointer' : undefined,
+                  }}
+                  onStartShouldSetResponder={() => true}
+                  onResponderGrant={() =>
+                    setSelectedIndex(prev => (point.index === prev ? null : point.index))
+                  }
+                  {...(Platform.OS === 'web' && {
+                    onMouseEnter: () => setSelectedIndex(point.index),
+                    onMouseLeave: () => setSelectedIndex(null),
+                  })}
+                />
+              );
+            })}
+
+            {/* X-axis labels (Erneuerbare %) */}
+            {[0, 1, 2, 3, 4].map(i => {
+              const value = minRenewable + (i / 4) * renewableRange;
+              const x = leftPadding + (i / 4) * (chartWidth - leftPadding - rightPadding);
+              return (
+                <Text
+                  key={`xlabel-${i}`}
+                  style={{
+                    position: 'absolute',
+                    left: x - 15,
+                    top: chartHeight - (isPhone ? 25 : 30),
+                    fontSize: 12,
+                    color: textColor,
+                    opacity: 0.6,
+                  }}
+                >
+                  {value.toFixed(0)}%
+                </Text>
+              );
+            })}
+
+            {/* Axis Labels */}
+            <Text
               style={{
                 position: 'absolute',
-                left: point.x - touchSize / 2,
-                top: point.y - touchSize / 2,
-                width: touchSize,
-                height: touchSize,
-                zIndex: 10,
-                cursor: Platform.OS === 'web' ? 'pointer' : undefined,
+                left: chartWidth / 2 - 60,
+                bottom: isPhone ? 0 : 3,
+                fontSize: 12,
+                color: textColor,
+                opacity: 0.6,
+                fontWeight: '600',
               }}
-              onStartShouldSetResponder={() => true}
-              onResponderGrant={() =>
-                setSelectedIndex(prev => (point.index === prev ? null : point.index))
-              }
-              {...(Platform.OS === 'web' && {
-                onMouseEnter: () => setSelectedIndex(point.index),
-                onMouseLeave: () => setSelectedIndex(null),
-              })}
-            />
-          );
-        })}
+            >
+              {labels.xAxisRenewables}
+            </Text>
+          </View>
+        </ScrollView>
 
-        {/* Y-axis labels (Preis) */}
+        {/* Y-axis labels - pinned outside the zoomable/scrollable content */}
         {[0, 1, 2, 3, 4].map(i => {
           const value = maxPrice - (i / 4) * priceRange;
           const y = padding + (i / 4) * (chartHeight - padding - bottomPadding);
@@ -411,44 +482,13 @@ function CorrelationScatterChartComponent({
           );
         })}
 
-        {/* X-axis labels (Erneuerbare %) */}
-        {[0, 1, 2, 3, 4].map(i => {
-          const value = minRenewable + (i / 4) * renewableRange;
-          const x = leftPadding + (i / 4) * (chartWidth - leftPadding - rightPadding);
-          return (
-            <Text
-              key={`xlabel-${i}`}
-              style={{
-                position: 'absolute',
-                left: x - 15,
-                top: chartHeight - (isPhone ? 25 : 30),
-                fontSize: 12,
-                color: textColor,
-                opacity: 0.6,
-              }}
-            >
-              {value.toFixed(0)}%
-            </Text>
-          );
-        })}
-
-        {/* Axis Labels */}
-        <Text
-          style={{
-            position: 'absolute',
-            left: chartWidth / 2 - 60,
-            bottom: isPhone ? 0 : 3,
-            fontSize: 12,
-            color: textColor,
-            opacity: 0.6,
-            fontWeight: '600',
-          }}
-        >
-          {labels.xAxisRenewables}
-        </Text>
         <Text style={getYAxisLabelStyle(chartHeight, -15, textColor, isPhone)}>
           {labels.yAxisPrice}
         </Text>
+
+        {isZoomed && (
+          <ZoomResetBadge onPress={resetZoom} colors={colors} accessibilityLabel={t.resetZoom} />
+        )}
       </View>
       {insightText && (
         <View

--- a/components/charts/PriceBarChart.tsx
+++ b/components/charts/PriceBarChart.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useCallback } from 'react';
-import { View, Text, Platform } from 'react-native';
+import { View, Text, Platform, ScrollView } from 'react-native';
 import Svg, { Rect, Line } from 'react-native-svg';
 import type { ThemeColors } from '../../utils/theme';
 import { getYAxisLabelStyle, getPriceColor } from '../../utils/chartHelpers';
@@ -7,7 +7,16 @@ import { GRID_FEES_AND_TAXES } from '../../utils/metrics';
 import { useChartDimensions } from '../../utils/chartUtils';
 import { arrayMin, arrayMax } from '../../utils/mathUtils';
 import { useSettingsContext } from '../../context/SettingsContext';
-import { ChartGrid, ChartCard, ChartTooltip, getTooltipLeft, NowMarkerLine } from './shared';
+import { useLanguageContext } from '../../context/LanguageContext';
+import {
+  ChartGrid,
+  ChartCard,
+  ChartTooltip,
+  getTooltipLeft,
+  NowMarkerLine,
+  useChartZoom,
+  ZoomResetBadge,
+} from './shared';
 
 interface PriceBarChartProps {
   title: string;
@@ -57,6 +66,7 @@ function PriceBarChartComponent({
 }: PriceBarChartProps) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const { priceDisplayMode } = useSettingsContext();
+  const { t } = useLanguageContext();
   const isMarketOnly = !forceStacked && priceDisplayMode === 'marketOnly';
 
   const handleBarInteraction = useCallback((index: number) => {
@@ -65,7 +75,7 @@ function PriceBarChartComponent({
 
   // Use centralized chart dimensions hook
   const {
-    chartWidth,
+    chartWidth: viewportWidth,
     chartHeight,
     leftPadding,
     padding,
@@ -76,6 +86,18 @@ function PriceBarChartComponent({
     isPhone,
     isLandscape,
   } = useChartDimensions();
+
+  // Pinch (mobile) / scroll (web) zoom (#355) — contentWidth replaces the static
+  // chartWidth for all internal x-position math below.
+  const {
+    contentWidth: chartWidth,
+    isZoomed,
+    resetZoom,
+    scrollRef,
+    scrollViewProps,
+    gestureContainerProps,
+    toViewportX,
+  } = useChartZoom(viewportWidth);
 
   // now must be outside useMemo so the "Jetzt" marker updates on every render
   const now = Date.now();
@@ -190,7 +212,7 @@ function PriceBarChartComponent({
 
           const x =
             leftPadding + ((item.timestamp - minTime) / timeRange) * (chartWidth - leftPadding);
-          const tooltipLeft = getTooltipLeft(x, 100, chartWidth);
+          const tooltipLeft = getTooltipLeft(toViewportX(x), 100, viewportWidth);
 
           return (
             <ChartTooltip
@@ -265,7 +287,7 @@ function PriceBarChartComponent({
           marginBottom: 0,
         }}
       >
-        <View>
+        <View style={{ flex: 1, marginRight: 8 }}>
           <Text
             style={{
               fontSize: isPhone ? 17 : 20,
@@ -273,6 +295,8 @@ function PriceBarChartComponent({
               marginBottom: 0,
               color: textColor,
             }}
+            numberOfLines={2}
+            ellipsizeMode="tail"
           >
             {title}
           </Text>
@@ -332,156 +356,231 @@ function PriceBarChartComponent({
           </View>
         )}
       </View>
-      <View style={{ height: chartHeight, width: chartWidth, position: 'relative' }}>
-        <ChartGrid
-          chartWidth={chartWidth}
-          chartHeight={chartHeight}
-          leftPadding={leftPadding}
-          rightPadding={rightPadding}
-          padding={padding}
-          bottomPadding={bottomPadding}
-          gridColor={gridColor}
-        />
-
-        {/* Bars (SVG) - Using pre-calculated bar data for performance */}
-        <Svg width={chartWidth} height={chartHeight}>
-          {barData.map(bar => {
-            // Render dashed placeholder for missing data
-            if (bar.marketPrice === null) {
-              return (
-                <Rect
-                  key={bar.index}
-                  x={bar.x - bar.barWidth / 2}
-                  y={padding}
-                  width={bar.barWidth}
-                  height={chartHeight - padding - bottomPadding}
-                  fill="none"
-                  stroke={gridColor}
-                  strokeWidth="1"
-                  strokeDasharray="4,4"
-                  opacity={0.3}
-                />
-              );
-            }
-
-            const isSelected = selectedIndex === bar.index;
-            const baseOpacity = bar.isInterpolated ? 0.4 : 0.9;
-            const selectedOpacity = bar.isInterpolated ? 0.6 : 1.0;
-
-            return (
-              <React.Fragment key={bar.index}>
-                <Rect
-                  x={bar.x - bar.barWidth / 2}
-                  y={bar.marketY}
-                  width={bar.barWidth}
-                  height={bar.marketBarHeight}
-                  fill={bar.color}
-                  opacity={isSelected ? selectedOpacity : baseOpacity}
-                  stroke={isSelected ? '#999999' : 'none'}
-                  strokeWidth={isSelected ? 2 : 0}
-                />
-                {!isMarketOnly && (
-                  <Rect
-                    x={bar.x - bar.barWidth / 2}
-                    y={bar.gridY}
-                    width={bar.barWidth}
-                    height={bar.gridBarHeight}
-                    fill="#757575"
-                    opacity={
-                      isSelected ? (bar.isInterpolated ? 0.5 : 0.8) : bar.isInterpolated ? 0.3 : 0.6
-                    }
-                    stroke={isSelected ? '#999999' : 'none'}
-                    strokeWidth={isSelected ? 2 : 0}
-                  />
-                )}
-              </React.Fragment>
-            );
-          })}
-
-          {/* Durchschnittslinie */}
-          <Line
-            x1={leftPadding}
-            y1={
-              chartHeight -
-              bottomPadding -
-              ((avgMarketPrice - min) / range) * (chartHeight - padding - bottomPadding)
-            }
-            x2={chartWidth - rightPadding}
-            y2={
-              chartHeight -
-              bottomPadding -
-              ((avgMarketPrice - min) / range) * (chartHeight - padding - bottomPadding)
-            }
-            stroke={textColor}
-            strokeWidth="2"
-            strokeDasharray="8,4"
-            opacity={0.5}
-          />
-
-          {/* "Jetzt" Markierung */}
-          {now >= minTime && now <= maxTime && (
-            <NowMarkerLine
-              now={now}
-              minTime={minTime}
-              timeRange={timeRange}
+      <View
+        style={{ height: chartHeight, width: viewportWidth, position: 'relative' }}
+        {...gestureContainerProps}
+      >
+        <ScrollView
+          ref={scrollRef}
+          {...scrollViewProps}
+          style={{ width: viewportWidth, height: chartHeight }}
+          contentContainerStyle={{ width: chartWidth, height: chartHeight }}
+        >
+          <View style={{ height: chartHeight, width: chartWidth, position: 'relative' }}>
+            <ChartGrid
               chartWidth={chartWidth}
               chartHeight={chartHeight}
               leftPadding={leftPadding}
               rightPadding={rightPadding}
               padding={padding}
               bottomPadding={bottomPadding}
+              gridColor={gridColor}
             />
-          )}
-        </Svg>
 
-        {/* Invisible touch/hover areas for bars - Using pre-calculated positions */}
-        {barData.map(bar => {
-          if (bar.marketPrice === null) return null;
+            {/* Bars (SVG) - Using pre-calculated bar data for performance */}
+            <Svg width={chartWidth} height={chartHeight}>
+              {barData.map(bar => {
+                // Render dashed placeholder for missing data
+                if (bar.marketPrice === null) {
+                  return (
+                    <Rect
+                      key={bar.index}
+                      x={bar.x - bar.barWidth / 2}
+                      y={padding}
+                      width={bar.barWidth}
+                      height={chartHeight - padding - bottomPadding}
+                      fill="none"
+                      stroke={gridColor}
+                      strokeWidth="1"
+                      strokeDasharray="4,4"
+                      opacity={0.3}
+                    />
+                  );
+                }
 
-          return (
-            <View
-              key={`touch-${bar.index}`}
+                const isSelected = selectedIndex === bar.index;
+                const baseOpacity = bar.isInterpolated ? 0.4 : 0.9;
+                const selectedOpacity = bar.isInterpolated ? 0.6 : 1.0;
+
+                return (
+                  <React.Fragment key={bar.index}>
+                    <Rect
+                      x={bar.x - bar.barWidth / 2}
+                      y={bar.marketY}
+                      width={bar.barWidth}
+                      height={bar.marketBarHeight}
+                      fill={bar.color}
+                      opacity={isSelected ? selectedOpacity : baseOpacity}
+                      stroke={isSelected ? '#999999' : 'none'}
+                      strokeWidth={isSelected ? 2 : 0}
+                    />
+                    {!isMarketOnly && (
+                      <Rect
+                        x={bar.x - bar.barWidth / 2}
+                        y={bar.gridY}
+                        width={bar.barWidth}
+                        height={bar.gridBarHeight}
+                        fill="#757575"
+                        opacity={
+                          isSelected
+                            ? bar.isInterpolated
+                              ? 0.5
+                              : 0.8
+                            : bar.isInterpolated
+                              ? 0.3
+                              : 0.6
+                        }
+                        stroke={isSelected ? '#999999' : 'none'}
+                        strokeWidth={isSelected ? 2 : 0}
+                      />
+                    )}
+                  </React.Fragment>
+                );
+              })}
+
+              {/* Durchschnittslinie */}
+              <Line
+                x1={leftPadding}
+                y1={
+                  chartHeight -
+                  bottomPadding -
+                  ((avgMarketPrice - min) / range) * (chartHeight - padding - bottomPadding)
+                }
+                x2={chartWidth - rightPadding}
+                y2={
+                  chartHeight -
+                  bottomPadding -
+                  ((avgMarketPrice - min) / range) * (chartHeight - padding - bottomPadding)
+                }
+                stroke={textColor}
+                strokeWidth="2"
+                strokeDasharray="8,4"
+                opacity={0.5}
+              />
+
+              {/* "Jetzt" Markierung */}
+              {now >= minTime && now <= maxTime && (
+                <NowMarkerLine
+                  now={now}
+                  minTime={minTime}
+                  timeRange={timeRange}
+                  chartWidth={chartWidth}
+                  chartHeight={chartHeight}
+                  leftPadding={leftPadding}
+                  rightPadding={rightPadding}
+                  padding={padding}
+                  bottomPadding={bottomPadding}
+                />
+              )}
+            </Svg>
+
+            {/* Invisible touch/hover areas for bars - Using pre-calculated positions */}
+            {barData.map(bar => {
+              if (bar.marketPrice === null) return null;
+
+              return (
+                <View
+                  key={`touch-${bar.index}`}
+                  style={{
+                    position: 'absolute',
+                    left: bar.x - bar.barWidth / 2,
+                    top: isMarketOnly ? bar.marketY : bar.gridY,
+                    width: bar.barWidth,
+                    height: isMarketOnly
+                      ? bar.marketBarHeight
+                      : bar.marketBarHeight + bar.gridBarHeight,
+                    zIndex: 10,
+                    cursor: Platform.OS === 'web' ? 'pointer' : undefined,
+                  }}
+                  onStartShouldSetResponder={() => true}
+                  onResponderGrant={() => handleBarInteraction(bar.index)}
+                  {...(Platform.OS === 'web' && {
+                    onMouseEnter: () => setSelectedIndex(bar.index),
+                    onMouseLeave: () => setSelectedIndex(null),
+                  })}
+                />
+              );
+            })}
+
+            {/* Durchschnittslinie Label */}
+            <Text
               style={{
                 position: 'absolute',
-                left: bar.x - bar.barWidth / 2,
-                top: isMarketOnly ? bar.marketY : bar.gridY,
-                width: bar.barWidth,
-                height: isMarketOnly
-                  ? bar.marketBarHeight
-                  : bar.marketBarHeight + bar.gridBarHeight,
-                zIndex: 10,
-                cursor: Platform.OS === 'web' ? 'pointer' : undefined,
+                right: rightPadding + 4,
+                top:
+                  chartHeight -
+                  bottomPadding -
+                  ((avgMarketPrice - min) / range) * (chartHeight - padding - bottomPadding) -
+                  11,
+                fontSize: 11,
+                color: textColor,
+                fontWeight: '700',
+                opacity: 0.7,
               }}
-              onStartShouldSetResponder={() => true}
-              onResponderGrant={() => handleBarInteraction(bar.index)}
-              {...(Platform.OS === 'web' && {
-                onMouseEnter: () => setSelectedIndex(bar.index),
-                onMouseLeave: () => setSelectedIndex(null),
-              })}
-            />
-          );
-        })}
+            >
+              {labels.average} {avgMarketPrice.toFixed(2)} ¢
+            </Text>
 
-        {/* Durchschnittslinie Label */}
-        <Text
-          style={{
-            position: 'absolute',
-            right: rightPadding + 4,
-            top:
-              chartHeight -
-              bottomPadding -
-              ((avgMarketPrice - min) / range) * (chartHeight - padding - bottomPadding) -
-              11,
-            fontSize: 11,
-            color: textColor,
-            fontWeight: '700',
-            opacity: 0.7,
-          }}
-        >
-          {labels.average} {avgMarketPrice.toFixed(2)} ¢
-        </Text>
+            {/* X-axis labels (every 6 hours) */}
+            {(() => {
+              const xAxisLabels = [];
+              const startDate = new Date(minTime);
+              const endDate = new Date(maxTime);
 
-        {/* Y-axis labels */}
+              const startHour = Math.ceil(startDate.getHours() / 6) * 6;
+              const current = new Date(startDate);
+              current.setHours(startHour, 0, 0, 0);
+
+              while (current <= endDate) {
+                const timestamp = current.getTime();
+                const x =
+                  leftPadding +
+                  ((timestamp - minTime) / timeRange) * (chartWidth - leftPadding - rightPadding);
+                const hour = current.getHours();
+
+                xAxisLabels.push(
+                  <Text
+                    key={`xlabel-${timestamp}`}
+                    style={{
+                      position: 'absolute',
+                      left: x - 10,
+                      top: chartHeight - bottomPadding + 5,
+                      fontSize: 11,
+                      color: textColor,
+                      opacity: 0.6,
+                      fontWeight: '600',
+                    }}
+                  >
+                    {hour}h
+                  </Text>
+                );
+
+                current.setHours(current.getHours() + 6);
+              }
+
+              return xAxisLabels;
+            })()}
+
+            {/* End-of-chart label */}
+            <Text
+              style={{
+                position: 'absolute',
+                right: 2,
+                bottom: bottomPadding + 4,
+                fontSize: 10,
+                color: textColor,
+                opacity: 0.35,
+                fontWeight: '700',
+                textTransform: 'uppercase',
+                letterSpacing: 0.6,
+              }}
+            >
+              EPEX
+            </Text>
+          </View>
+        </ScrollView>
+
+        {/* Y-axis labels - pinned outside the zoomable/scrollable content */}
         {[0, 1, 2, 3, 4].map(i => {
           const value = maxTotal - (i / 4) * range;
           const y = padding + (i / 4) * (chartHeight - padding - bottomPadding);
@@ -504,65 +603,12 @@ function PriceBarChartComponent({
           );
         })}
 
-        {/* X-axis labels (every 6 hours) */}
-        {(() => {
-          const xAxisLabels = [];
-          const startDate = new Date(minTime);
-          const endDate = new Date(maxTime);
-
-          const startHour = Math.ceil(startDate.getHours() / 6) * 6;
-          const current = new Date(startDate);
-          current.setHours(startHour, 0, 0, 0);
-
-          while (current <= endDate) {
-            const timestamp = current.getTime();
-            const x =
-              leftPadding +
-              ((timestamp - minTime) / timeRange) * (chartWidth - leftPadding - rightPadding);
-            const hour = current.getHours();
-
-            xAxisLabels.push(
-              <Text
-                key={`xlabel-${timestamp}`}
-                style={{
-                  position: 'absolute',
-                  left: x - 10,
-                  top: chartHeight - bottomPadding + 5,
-                  fontSize: 11,
-                  color: textColor,
-                  opacity: 0.6,
-                  fontWeight: '600',
-                }}
-              >
-                {hour}h
-              </Text>
-            );
-
-            current.setHours(current.getHours() + 6);
-          }
-
-          return xAxisLabels;
-        })()}
-
-        {/* End-of-chart label */}
-        <Text
-          style={{
-            position: 'absolute',
-            right: 2,
-            bottom: bottomPadding + 4,
-            fontSize: 10,
-            color: textColor,
-            opacity: 0.35,
-            fontWeight: '700',
-            textTransform: 'uppercase',
-            letterSpacing: 0.6,
-          }}
-        >
-          EPEX
-        </Text>
-
         {/* Y-Achsen-Label */}
         <Text style={getYAxisLabelStyle(chartHeight, -15, textColor, isPhone)}>{labels.yAxis}</Text>
+
+        {isZoomed && (
+          <ZoomResetBadge onPress={resetZoom} colors={colors} accessibilityLabel={t.resetZoom} />
+        )}
       </View>
       {interactionHint && (
         <Text

--- a/components/charts/RenewableBarChart.tsx
+++ b/components/charts/RenewableBarChart.tsx
@@ -1,11 +1,20 @@
 import React, { useState, useMemo, useCallback } from 'react';
-import { View, Text, Platform } from 'react-native';
+import { View, Text, Platform, ScrollView } from 'react-native';
 import Svg, { Rect, Line, Polyline } from 'react-native-svg';
 import type { ThemeColors } from '../../utils/theme';
 import { getYAxisLabelStyle } from '../../utils/chartHelpers';
 import { useChartDimensions } from '../../utils/chartUtils';
 import { arrayMin, arrayMax } from '../../utils/mathUtils';
-import { ChartGrid, ChartCard, ChartTooltip, getTooltipLeft, NowMarkerLine } from './shared';
+import { useLanguageContext } from '../../context/LanguageContext';
+import {
+  ChartGrid,
+  ChartCard,
+  ChartTooltip,
+  getTooltipLeft,
+  NowMarkerLine,
+  useChartZoom,
+  ZoomResetBadge,
+} from './shared';
 
 // Performance: Move color helpers outside component for stable references
 const interpolateColor = (color1: number[], color2: number[], factor: number) => {
@@ -84,6 +93,7 @@ function RenewableBarChartComponent({
   accentColor,
 }: RenewableBarChartProps) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const { t } = useLanguageContext();
 
   const handleBarInteraction = useCallback((index: number) => {
     setSelectedIndex(prev => (index === prev ? null : index));
@@ -91,7 +101,7 @@ function RenewableBarChartComponent({
 
   // Use centralized chart dimensions hook
   const {
-    chartWidth,
+    chartWidth: viewportWidth,
     chartHeight,
     leftPadding,
     padding,
@@ -102,6 +112,18 @@ function RenewableBarChartComponent({
     isPhone,
     isLandscape,
   } = useChartDimensions();
+
+  // Pinch (mobile) / scroll (web) zoom (#355) — contentWidth replaces the static
+  // chartWidth for all internal x-position math below.
+  const {
+    contentWidth: chartWidth,
+    isZoomed,
+    resetZoom,
+    scrollRef,
+    scrollViewProps,
+    gestureContainerProps,
+    toViewportX,
+  } = useChartZoom(viewportWidth);
 
   // now must be outside useMemo so the "Jetzt" marker updates on every render
   const now = Date.now();
@@ -220,7 +242,7 @@ function RenewableBarChartComponent({
 
           const x =
             leftPadding + ((item.timestamp - minTime) / timeRange) * (chartWidth - leftPadding);
-          const tooltipLeft = getTooltipLeft(x, 80, chartWidth);
+          const tooltipLeft = getTooltipLeft(toViewportX(x), 80, viewportWidth);
 
           return (
             <ChartTooltip
@@ -243,7 +265,7 @@ function RenewableBarChartComponent({
           marginBottom: 0,
         }}
       >
-        <View>
+        <View style={{ flex: 1, marginRight: 8 }}>
           <Text
             style={{
               fontSize: isPhone ? 16 : 18,
@@ -251,6 +273,8 @@ function RenewableBarChartComponent({
               marginBottom: 0,
               color: textColor,
             }}
+            numberOfLines={2}
+            ellipsizeMode="tail"
           >
             {title}
           </Text>
@@ -308,249 +332,302 @@ function RenewableBarChartComponent({
           </View>
         )}
       </View>
-      <View style={{ height: chartHeight, width: chartWidth, position: 'relative' }}>
-        <ChartGrid
-          chartWidth={chartWidth}
-          chartHeight={chartHeight}
-          leftPadding={leftPadding}
-          rightPadding={rightPadding}
-          padding={padding}
-          bottomPadding={bottomPadding}
-          gridColor={gridColor}
-        />
-
-        {/* Bars (SVG) - Using pre-calculated bar data for performance */}
-        <Svg width={chartWidth} height={chartHeight}>
-          {barData.map(bar => {
-            // Render gray fading bar for missing data
-            if (bar.value === null) {
-              // Seeded random for consistent but varied heights
-              const seed = data[bar.index].timestamp % 1000;
-              const random = Math.sin(seed) * 10000;
-              const randomFactor = (random - Math.floor(random)) * 0.3 + 0.9; // Range: 0.9 to 1.2
-
-              // Calculate fade-out height: based on last valid value (not average)
-              const fadeMaxValue = lastValidValue * randomFactor;
-              const clampedFadeMax = Math.min(Math.max(fadeMaxValue, min), max);
-              const fadeHeight =
-                ((clampedFadeMax - min) / range) * (chartHeight - padding - bottomPadding);
-              const fadeY = chartHeight - bottomPadding - fadeHeight;
-
-              // Create fading effect with multiple segments
-              const segments = 5;
-              const segmentHeight = fadeHeight / segments;
-
-              return (
-                <React.Fragment key={bar.index}>
-                  {Array.from({ length: segments }).map((_, segIndex) => {
-                    const segY = fadeY + segIndex * segmentHeight;
-                    // Opacity increases as we go down (from 0.0 at top to 0.25 at bottom)
-                    const opacity = 0.25 * (segIndex / (segments - 1));
-
-                    return (
-                      <Rect
-                        key={`${bar.index}-seg-${segIndex}`}
-                        x={bar.x - bar.barWidth / 2}
-                        y={segY}
-                        width={bar.barWidth}
-                        height={segmentHeight}
-                        fill={gridColor}
-                        opacity={opacity}
-                      />
-                    );
-                  })}
-                </React.Fragment>
-              );
-            }
-
-            const isSelected = selectedIndex === bar.index;
-            const baseOpacity = bar.isInterpolated ? 0.4 : 0.9;
-            const selectedOpacity = bar.isInterpolated ? 0.6 : 1.0;
-
-            // Wenn Wert über 100%, Balken zweiteilen (use pre-calculated values)
-            if (bar.value > 100) {
-              return (
-                <React.Fragment key={bar.index}>
-                  <Rect
-                    x={bar.x - bar.barWidth / 2}
-                    y={bar.baseY}
-                    width={bar.barWidth}
-                    height={bar.baseHeight}
-                    fill={bar.baseColor}
-                    opacity={isSelected ? selectedOpacity : baseOpacity}
-                    stroke={isSelected ? '#999999' : 'none'}
-                    strokeWidth={isSelected ? 2 : 0}
-                  />
-                  <Rect
-                    x={bar.x - bar.barWidth / 2}
-                    y={bar.overY}
-                    width={bar.barWidth}
-                    height={bar.overHeight}
-                    fill="#90A4AE"
-                    opacity={isSelected ? selectedOpacity : baseOpacity}
-                    stroke={isSelected ? '#999999' : 'none'}
-                    strokeWidth={isSelected ? 2 : 0}
-                  />
-                </React.Fragment>
-              );
-            }
-
-            return (
-              <Rect
-                key={bar.index}
-                x={bar.x - bar.barWidth / 2}
-                y={bar.y}
-                width={bar.barWidth}
-                height={bar.barHeight}
-                fill={bar.color}
-                opacity={isSelected ? selectedOpacity : baseOpacity}
-                stroke={isSelected ? '#999999' : 'none'}
-                strokeWidth={isSelected ? 2 : 0}
-              />
-            );
-          })}
-
-          {/* Durchschnittslinie */}
-          <Line
-            x1={leftPadding}
-            y1={
-              chartHeight -
-              bottomPadding -
-              ((avgValue - min) / range) * (chartHeight - padding - bottomPadding)
-            }
-            x2={chartWidth - rightPadding}
-            y2={
-              chartHeight -
-              bottomPadding -
-              ((avgValue - min) / range) * (chartHeight - padding - bottomPadding)
-            }
-            stroke={textColor}
-            strokeWidth="2"
-            strokeDasharray="8,4"
-            opacity={0.5}
-          />
-
-          {/* Regionale Datenlinie - gestrichelt */}
-          {showRegionalLine &&
-            (() => {
-              const regionalPoints = data
-                .map((d, _index) => ({
-                  x:
-                    leftPadding +
-                    ((d.timestamp - minTime) / timeRange) *
-                      (chartWidth - leftPadding - rightPadding),
-                  y:
-                    d.renewableShareRegional !== null && d.renewableShareRegional !== undefined
-                      ? chartHeight -
-                        bottomPadding -
-                        ((d.renewableShareRegional - min) / range) *
-                          (chartHeight - padding - bottomPadding)
-                      : null,
-                  value: d.renewableShareRegional,
-                }))
-                .filter(p => p.y !== null);
-
-              if (regionalPoints.length === 0) return null;
-
-              const pointsString = regionalPoints.map(p => `${p.x},${p.y}`).join(' ');
-              const regionalAvg =
-                regionalPoints.reduce((sum, p) => sum + (p.value || 0), 0) / regionalPoints.length;
-
-              return (
-                <>
-                  <Polyline
-                    points={pointsString}
-                    stroke="#FF9800"
-                    strokeWidth="3"
-                    strokeDasharray="6,6"
-                    fill="none"
-                    opacity={0.8}
-                  />
-                  {labels.regional && (
-                    <Text
-                      style={{
-                        position: 'absolute',
-                        right: rightPadding + 4,
-                        top:
-                          chartHeight -
-                          bottomPadding -
-                          ((regionalAvg - min) / range) * (chartHeight - padding - bottomPadding) +
-                          12,
-                        fontSize: 12,
-                        color: '#FF9800',
-                        fontWeight: '600',
-                        opacity: 0.9,
-                      }}
-                    >
-                      {labels.regional} {regionalAvg.toFixed(1)}%
-                    </Text>
-                  )}
-                </>
-              );
-            })()}
-
-          {/* "Jetzt" Markierung */}
-          {now >= minTime && now <= maxTime && (
-            <NowMarkerLine
-              now={now}
-              minTime={minTime}
-              timeRange={timeRange}
+      <View
+        style={{ height: chartHeight, width: viewportWidth, position: 'relative' }}
+        {...gestureContainerProps}
+      >
+        <ScrollView
+          ref={scrollRef}
+          {...scrollViewProps}
+          style={{ width: viewportWidth, height: chartHeight }}
+          contentContainerStyle={{ width: chartWidth, height: chartHeight }}
+        >
+          <View style={{ height: chartHeight, width: chartWidth, position: 'relative' }}>
+            <ChartGrid
               chartWidth={chartWidth}
               chartHeight={chartHeight}
               leftPadding={leftPadding}
               rightPadding={rightPadding}
               padding={padding}
               bottomPadding={bottomPadding}
+              gridColor={gridColor}
             />
-          )}
-        </Svg>
 
-        {/* Invisible touch/hover areas for bars - Using pre-calculated positions */}
-        {barData.map(bar => {
-          if (bar.value === null) return null;
+            {/* Bars (SVG) - Using pre-calculated bar data for performance */}
+            <Svg width={chartWidth} height={chartHeight}>
+              {barData.map(bar => {
+                // Render gray fading bar for missing data
+                if (bar.value === null) {
+                  // Seeded random for consistent but varied heights
+                  const seed = data[bar.index].timestamp % 1000;
+                  const random = Math.sin(seed) * 10000;
+                  const randomFactor = (random - Math.floor(random)) * 0.3 + 0.9; // Range: 0.9 to 1.2
 
-          return (
-            <View
-              key={`touch-${bar.index}`}
+                  // Calculate fade-out height: based on last valid value (not average)
+                  const fadeMaxValue = lastValidValue * randomFactor;
+                  const clampedFadeMax = Math.min(Math.max(fadeMaxValue, min), max);
+                  const fadeHeight =
+                    ((clampedFadeMax - min) / range) * (chartHeight - padding - bottomPadding);
+                  const fadeY = chartHeight - bottomPadding - fadeHeight;
+
+                  // Create fading effect with multiple segments
+                  const segments = 5;
+                  const segmentHeight = fadeHeight / segments;
+
+                  return (
+                    <React.Fragment key={bar.index}>
+                      {Array.from({ length: segments }).map((_, segIndex) => {
+                        const segY = fadeY + segIndex * segmentHeight;
+                        // Opacity increases as we go down (from 0.0 at top to 0.25 at bottom)
+                        const opacity = 0.25 * (segIndex / (segments - 1));
+
+                        return (
+                          <Rect
+                            key={`${bar.index}-seg-${segIndex}`}
+                            x={bar.x - bar.barWidth / 2}
+                            y={segY}
+                            width={bar.barWidth}
+                            height={segmentHeight}
+                            fill={gridColor}
+                            opacity={opacity}
+                          />
+                        );
+                      })}
+                    </React.Fragment>
+                  );
+                }
+
+                const isSelected = selectedIndex === bar.index;
+                const baseOpacity = bar.isInterpolated ? 0.4 : 0.9;
+                const selectedOpacity = bar.isInterpolated ? 0.6 : 1.0;
+
+                // Wenn Wert über 100%, Balken zweiteilen (use pre-calculated values)
+                if (bar.value > 100) {
+                  return (
+                    <React.Fragment key={bar.index}>
+                      <Rect
+                        x={bar.x - bar.barWidth / 2}
+                        y={bar.baseY}
+                        width={bar.barWidth}
+                        height={bar.baseHeight}
+                        fill={bar.baseColor}
+                        opacity={isSelected ? selectedOpacity : baseOpacity}
+                        stroke={isSelected ? '#999999' : 'none'}
+                        strokeWidth={isSelected ? 2 : 0}
+                      />
+                      <Rect
+                        x={bar.x - bar.barWidth / 2}
+                        y={bar.overY}
+                        width={bar.barWidth}
+                        height={bar.overHeight}
+                        fill="#90A4AE"
+                        opacity={isSelected ? selectedOpacity : baseOpacity}
+                        stroke={isSelected ? '#999999' : 'none'}
+                        strokeWidth={isSelected ? 2 : 0}
+                      />
+                    </React.Fragment>
+                  );
+                }
+
+                return (
+                  <Rect
+                    key={bar.index}
+                    x={bar.x - bar.barWidth / 2}
+                    y={bar.y}
+                    width={bar.barWidth}
+                    height={bar.barHeight}
+                    fill={bar.color}
+                    opacity={isSelected ? selectedOpacity : baseOpacity}
+                    stroke={isSelected ? '#999999' : 'none'}
+                    strokeWidth={isSelected ? 2 : 0}
+                  />
+                );
+              })}
+
+              {/* Durchschnittslinie */}
+              <Line
+                x1={leftPadding}
+                y1={
+                  chartHeight -
+                  bottomPadding -
+                  ((avgValue - min) / range) * (chartHeight - padding - bottomPadding)
+                }
+                x2={chartWidth - rightPadding}
+                y2={
+                  chartHeight -
+                  bottomPadding -
+                  ((avgValue - min) / range) * (chartHeight - padding - bottomPadding)
+                }
+                stroke={textColor}
+                strokeWidth="2"
+                strokeDasharray="8,4"
+                opacity={0.5}
+              />
+
+              {/* Regionale Datenlinie - gestrichelt */}
+              {showRegionalLine &&
+                (() => {
+                  const regionalPoints = data
+                    .map((d, _index) => ({
+                      x:
+                        leftPadding +
+                        ((d.timestamp - minTime) / timeRange) *
+                          (chartWidth - leftPadding - rightPadding),
+                      y:
+                        d.renewableShareRegional !== null && d.renewableShareRegional !== undefined
+                          ? chartHeight -
+                            bottomPadding -
+                            ((d.renewableShareRegional - min) / range) *
+                              (chartHeight - padding - bottomPadding)
+                          : null,
+                      value: d.renewableShareRegional,
+                    }))
+                    .filter(p => p.y !== null);
+
+                  if (regionalPoints.length === 0) return null;
+
+                  const pointsString = regionalPoints.map(p => `${p.x},${p.y}`).join(' ');
+                  const regionalAvg =
+                    regionalPoints.reduce((sum, p) => sum + (p.value || 0), 0) /
+                    regionalPoints.length;
+
+                  return (
+                    <>
+                      <Polyline
+                        points={pointsString}
+                        stroke="#FF9800"
+                        strokeWidth="3"
+                        strokeDasharray="6,6"
+                        fill="none"
+                        opacity={0.8}
+                      />
+                      {labels.regional && (
+                        <Text
+                          style={{
+                            position: 'absolute',
+                            right: rightPadding + 4,
+                            top:
+                              chartHeight -
+                              bottomPadding -
+                              ((regionalAvg - min) / range) *
+                                (chartHeight - padding - bottomPadding) +
+                              12,
+                            fontSize: 12,
+                            color: '#FF9800',
+                            fontWeight: '600',
+                            opacity: 0.9,
+                          }}
+                        >
+                          {labels.regional} {regionalAvg.toFixed(1)}%
+                        </Text>
+                      )}
+                    </>
+                  );
+                })()}
+
+              {/* "Jetzt" Markierung */}
+              {now >= minTime && now <= maxTime && (
+                <NowMarkerLine
+                  now={now}
+                  minTime={minTime}
+                  timeRange={timeRange}
+                  chartWidth={chartWidth}
+                  chartHeight={chartHeight}
+                  leftPadding={leftPadding}
+                  rightPadding={rightPadding}
+                  padding={padding}
+                  bottomPadding={bottomPadding}
+                />
+              )}
+            </Svg>
+
+            {/* Invisible touch/hover areas for bars - Using pre-calculated positions */}
+            {barData.map(bar => {
+              if (bar.value === null) return null;
+
+              return (
+                <View
+                  key={`touch-${bar.index}`}
+                  style={{
+                    position: 'absolute',
+                    left: bar.x - bar.barWidth / 2,
+                    top: bar.y,
+                    width: bar.barWidth,
+                    height: bar.barHeight,
+                    zIndex: 10,
+                    cursor: Platform.OS === 'web' ? 'pointer' : undefined,
+                  }}
+                  onStartShouldSetResponder={() => true}
+                  onResponderGrant={() => handleBarInteraction(bar.index)}
+                  {...(Platform.OS === 'web' && {
+                    onMouseEnter: () => setSelectedIndex(bar.index),
+                    onMouseLeave: () => setSelectedIndex(null),
+                  })}
+                />
+              );
+            })}
+
+            {/* Durchschnittslinie Label */}
+            <Text
               style={{
                 position: 'absolute',
-                left: bar.x - bar.barWidth / 2,
-                top: bar.y,
-                width: bar.barWidth,
-                height: bar.barHeight,
-                zIndex: 10,
-                cursor: Platform.OS === 'web' ? 'pointer' : undefined,
+                right: rightPadding + 4,
+                top:
+                  chartHeight -
+                  bottomPadding -
+                  ((avgValue - min) / range) * (chartHeight - padding - bottomPadding) -
+                  12,
+                fontSize: 12,
+                color: textColor,
+                fontWeight: '600',
+                opacity: 0.7,
               }}
-              onStartShouldSetResponder={() => true}
-              onResponderGrant={() => handleBarInteraction(bar.index)}
-              {...(Platform.OS === 'web' && {
-                onMouseEnter: () => setSelectedIndex(bar.index),
-                onMouseLeave: () => setSelectedIndex(null),
-              })}
-            />
-          );
-        })}
+            >
+              {labels.average} {avgValue.toFixed(1)}%
+            </Text>
 
-        {/* Durchschnittslinie Label */}
-        <Text
-          style={{
-            position: 'absolute',
-            right: rightPadding + 4,
-            top:
-              chartHeight -
-              bottomPadding -
-              ((avgValue - min) / range) * (chartHeight - padding - bottomPadding) -
-              12,
-            fontSize: 12,
-            color: textColor,
-            fontWeight: '600',
-            opacity: 0.7,
-          }}
-        >
-          {labels.average} {avgValue.toFixed(1)}%
-        </Text>
+            {/* X-axis labels (every 6 hours) */}
+            {(() => {
+              const xAxisLabels = [];
+              const startDate = new Date(minTime);
+              const endDate = new Date(maxTime);
 
-        {/* Y-axis labels */}
+              const startHour = Math.ceil(startDate.getHours() / 6) * 6;
+              const current = new Date(startDate);
+              current.setHours(startHour, 0, 0, 0);
+
+              while (current <= endDate) {
+                const timestamp = current.getTime();
+                const x =
+                  leftPadding +
+                  ((timestamp - minTime) / timeRange) * (chartWidth - leftPadding - rightPadding);
+                const hour = current.getHours();
+
+                xAxisLabels.push(
+                  <Text
+                    key={`xlabel-${timestamp}`}
+                    style={{
+                      position: 'absolute',
+                      left: x - 10,
+                      top: chartHeight - bottomPadding + 5,
+                      fontSize: 12,
+                      color: textColor,
+                      opacity: 0.6,
+                    }}
+                  >
+                    {hour}h
+                  </Text>
+                );
+
+                current.setHours(current.getHours() + 6);
+              }
+
+              return xAxisLabels;
+            })()}
+          </View>
+        </ScrollView>
+
+        {/* Y-axis labels - pinned outside the zoomable/scrollable content */}
         {[0, 1, 2, 3, 4].map(i => {
           const value = max - (i / 4) * range;
           const y = padding + (i / 4) * (chartHeight - padding - bottomPadding);
@@ -573,47 +650,12 @@ function RenewableBarChartComponent({
           );
         })}
 
-        {/* X-axis labels (every 6 hours) */}
-        {(() => {
-          const xAxisLabels = [];
-          const startDate = new Date(minTime);
-          const endDate = new Date(maxTime);
-
-          const startHour = Math.ceil(startDate.getHours() / 6) * 6;
-          const current = new Date(startDate);
-          current.setHours(startHour, 0, 0, 0);
-
-          while (current <= endDate) {
-            const timestamp = current.getTime();
-            const x =
-              leftPadding +
-              ((timestamp - minTime) / timeRange) * (chartWidth - leftPadding - rightPadding);
-            const hour = current.getHours();
-
-            xAxisLabels.push(
-              <Text
-                key={`xlabel-${timestamp}`}
-                style={{
-                  position: 'absolute',
-                  left: x - 10,
-                  top: chartHeight - bottomPadding + 5,
-                  fontSize: 12,
-                  color: textColor,
-                  opacity: 0.6,
-                }}
-              >
-                {hour}h
-              </Text>
-            );
-
-            current.setHours(current.getHours() + 6);
-          }
-
-          return xAxisLabels;
-        })()}
-
         {/* Y-Achsen-Label */}
         <Text style={getYAxisLabelStyle(chartHeight, -15, textColor, isPhone)}>{labels.yAxis}</Text>
+
+        {isZoomed && (
+          <ZoomResetBadge onPress={resetZoom} colors={colors} accessibilityLabel={t.resetZoom} />
+        )}
       </View>
       {interactionHint && (
         <Text

--- a/components/charts/shared/ZoomResetBadge.tsx
+++ b/components/charts/shared/ZoomResetBadge.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { Pressable, Text, StyleSheet } from 'react-native';
+import { borderRadius } from '../../../utils/designSystem';
+import type { ThemeColors } from '../../../utils/theme';
+
+interface ZoomResetBadgeProps {
+  onPress: () => void;
+  colors: ThemeColors;
+  accessibilityLabel: string;
+}
+
+function ZoomResetBadgeComponent({ onPress, colors, accessibilityLabel }: ZoomResetBadgeProps) {
+  return (
+    <Pressable
+      onPress={onPress}
+      style={[
+        styles.badge,
+        { backgroundColor: colors.surfaceSecondary, borderColor: colors.gridLine },
+      ]}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      hitSlop={8}
+    >
+      <Text style={[styles.label, { color: colors.text }]}>⟲</Text>
+    </Pressable>
+  );
+}
+
+export const ZoomResetBadge = React.memo(ZoomResetBadgeComponent);
+
+const styles = StyleSheet.create({
+  badge: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    width: 24,
+    height: 24,
+    borderRadius: borderRadius.full,
+    borderWidth: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 20,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: '700',
+  },
+});

--- a/components/charts/shared/index.ts
+++ b/components/charts/shared/index.ts
@@ -2,3 +2,6 @@ export { ChartGrid } from './ChartGrid';
 export { NowMarkerLine, NowMarkerLabel } from './NowMarker';
 export { ChartCard } from './ChartCard';
 export { ChartTooltip, getTooltipLeft } from './ChartTooltip';
+export { useChartZoom } from './useChartZoom';
+export type { UseChartZoomResult } from './useChartZoom';
+export { ZoomResetBadge } from './ZoomResetBadge';

--- a/components/charts/shared/useChartZoom.ts
+++ b/components/charts/shared/useChartZoom.ts
@@ -1,0 +1,134 @@
+import { useCallback, useRef, useState } from 'react';
+import {
+  Platform,
+  PanResponder,
+  type ScrollView,
+  type GestureResponderEvent,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+} from 'react-native';
+
+const MIN_SCALE = 1;
+const MAX_SCALE = 3;
+const WHEEL_ZOOM_SPEED = 0.0015;
+
+export interface ChartZoomScrollViewProps {
+  horizontal: true;
+  scrollEnabled: boolean;
+  showsHorizontalScrollIndicator: boolean;
+  onScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+  scrollEventThrottle: number;
+}
+
+export interface UseChartZoomResult {
+  /** Current zoom factor (1 = no zoom). */
+  scale: number;
+  /** Zoomed width of the scrollable chart content. */
+  contentWidth: number;
+  /** Whether the chart is currently zoomed in. */
+  isZoomed: boolean;
+  /** Resets zoom to 1x and scrolls back to the start. */
+  resetZoom: () => void;
+  /** Ref to attach to the horizontal ScrollView wrapping the chart content. */
+  scrollRef: React.RefObject<ScrollView | null>;
+  /** Props to spread onto the horizontal ScrollView. */
+  scrollViewProps: ChartZoomScrollViewProps;
+  /** Props to spread onto the outer (non-scrolling) chart container for gesture handling. */
+  gestureContainerProps: object;
+  /** Converts an x coordinate in (zoomed) content space to viewport space, accounting for scroll offset. */
+  toViewportX: (contentX: number) => number;
+}
+
+/**
+ * Shared pinch-to-zoom (native) / scroll-to-zoom (web) behavior for SVG bar/scatter charts (#355).
+ * Consumers use `contentWidth` in place of the static chart width for all internal
+ * x-position math, and wrap that content in a horizontal ScrollView using `scrollViewProps`.
+ */
+export function useChartZoom(viewportWidth: number): UseChartZoomResult {
+  const [scale, setScale] = useState(1);
+  const [scrollX, setScrollX] = useState(0);
+  const scrollRef = useRef<ScrollView>(null);
+  const pinchStartDistance = useRef<number | null>(null);
+  const pinchStartScale = useRef(1);
+
+  const contentWidth = Math.round(viewportWidth * scale);
+  const isZoomed = scale > 1.01;
+
+  const resetZoom = useCallback(() => {
+    setScale(1);
+    setScrollX(0);
+    scrollRef.current?.scrollTo({ x: 0, animated: true });
+  }, []);
+
+  const onScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    setScrollX(event.nativeEvent.contentOffset.x);
+  }, []);
+
+  const getDistance = (touches: GestureResponderEvent['nativeEvent']['touches']) => {
+    const [a, b] = touches;
+    return Math.hypot(a.pageX - b.pageX, a.pageY - b.pageY);
+  };
+
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponderCapture: evt => evt.nativeEvent.touches.length === 2,
+      onMoveShouldSetPanResponderCapture: evt => evt.nativeEvent.touches.length === 2,
+      onPanResponderGrant: evt => {
+        const { touches } = evt.nativeEvent;
+        if (touches.length === 2) {
+          pinchStartDistance.current = getDistance(touches);
+          pinchStartScale.current = scale;
+        }
+      },
+      onPanResponderMove: evt => {
+        const { touches } = evt.nativeEvent;
+        if (touches.length === 2 && pinchStartDistance.current) {
+          const distance = getDistance(touches);
+          const ratio = distance / pinchStartDistance.current;
+          const nextScale = Math.min(
+            MAX_SCALE,
+            Math.max(MIN_SCALE, pinchStartScale.current * ratio)
+          );
+          setScale(nextScale);
+        }
+      },
+      onPanResponderRelease: () => {
+        pinchStartDistance.current = null;
+      },
+      onPanResponderTerminate: () => {
+        pinchStartDistance.current = null;
+      },
+    })
+  ).current;
+
+  // Web: wheel/trackpad scroll over the chart zooms in/out (matches #355 "Scroll (Web)" ask).
+  const handleWheel = useCallback((event: { deltaY: number; preventDefault?: () => void }) => {
+    event.preventDefault?.();
+    setScale(prev => {
+      const next = prev - event.deltaY * WHEEL_ZOOM_SPEED * prev;
+      return Math.min(MAX_SCALE, Math.max(MIN_SCALE, next));
+    });
+  }, []);
+
+  const gestureContainerProps =
+    Platform.OS === 'web' ? { onWheel: handleWheel } : panResponder.panHandlers;
+
+  const toViewportX = useCallback((contentX: number) => contentX - scrollX, [scrollX]);
+
+  return {
+    scale,
+    contentWidth,
+    isZoomed,
+    resetZoom,
+    scrollRef,
+    scrollViewProps: {
+      horizontal: true,
+      scrollEnabled: isZoomed,
+      showsHorizontalScrollIndicator: isZoomed,
+      onScroll,
+      scrollEventThrottle: 16,
+    },
+    gestureContainerProps,
+    toViewportX,
+  };
+}

--- a/services/historicalDataStore.ts
+++ b/services/historicalDataStore.ts
@@ -59,6 +59,15 @@ export interface HistoryStorageInfo {
 }
 
 /**
+ * Auflösung für den Server-Fallback-Download eines Tages (Issue #334).
+ * 'hourly' lädt die vorab-aggregierte, deutlich kleinere `<date>-hourly.json`
+ * Variante (falls für den Tag/Land vorhanden) statt der vollen 15-Min-Auflösung –
+ * relevant für lange Zeiträume (z.B. 30-Tage-Ansicht), wo die App die Daten
+ * ohnehin clientseitig weiter aggregiert (siehe dataAggregation.ts).
+ */
+export type HistoryResolution = 'raw' | 'hourly';
+
+/**
  * Liefert YYYY-MM-DD in der angegebenen Zeitzone für einen Timestamp (ms).
  *
  * Default: 'Europe/Berlin'. NL nutzt 'Europe/Amsterdam' = identisches
@@ -126,12 +135,14 @@ export class HistoricalDataStore {
 
   /**
    * URL der serverseitigen Tages-History – Pfad aus der Länder-Registry.
+   * `resolution: 'hourly'` zeigt auf die kleinere, vorab-aggregierte Variante (#334).
    */
-  private historyDayUrl(date: string): string {
+  private historyDayUrl(date: string, resolution: HistoryResolution = 'raw'): string {
     const prefix = COUNTRIES[this.country].historyPathPrefix;
+    const suffix = resolution === 'hourly' ? `${date}-hourly.json` : `${date}.json`;
     return Platform.OS === 'web'
-      ? `./${prefix}${date}.json`
-      : `https://s540d.github.io/Energy_Price_Germany/${prefix}${date}.json`;
+      ? `./${prefix}${suffix}`
+      : `https://s540d.github.io/Energy_Price_Germany/${prefix}${suffix}`;
   }
 
   private dayString(ts: number): string {
@@ -278,12 +289,30 @@ export class HistoricalDataStore {
   /**
    * Lädt eine serverseitige Tages-History und schreibt sie in den Store.
    * 404/Fehler werden still ignoriert. Markiert den Tag als angefragt.
+   *
+   * Bei `resolution: 'hourly'` wird zunächst die kleinere `-hourly.json`
+   * Variante versucht; existiert sie (noch) nicht für diesen Tag/Land, wird
+   * transparent auf die volle Auflösung zurückgefallen (#334).
    */
-  private async loadServerDayIntoStore(date: string, index: HistoryIndex): Promise<void> {
+  private async loadServerDayIntoStore(
+    date: string,
+    index: HistoryIndex,
+    resolution: HistoryResolution = 'raw'
+  ): Promise<void> {
     this.serverFetchAttempted.add(date);
     try {
-      const url = `${this.historyDayUrl(date)}?v=${Date.now()}`;
-      const response = await fetchWithTimeout(url, {}, 10000);
+      let response = await fetchWithTimeout(
+        `${this.historyDayUrl(date, resolution)}?v=${Date.now()}`,
+        {},
+        10000
+      );
+      if (!response.ok && resolution === 'hourly') {
+        response = await fetchWithTimeout(
+          `${this.historyDayUrl(date, 'raw')}?v=${Date.now()}`,
+          {},
+          10000
+        );
+      }
       if (!response.ok) return;
 
       const json = await response.json();
@@ -313,11 +342,17 @@ export class HistoricalDataStore {
    * (Issue #307 – Gerätecache primär, Server als Fallback).
    *
    * @param allowServerFallback Server-Fallback deaktivieren (z.B. offline-only)
+   * @param resolution Auflösung für neu nachgeladene Tage; 'hourly' reduziert das
+   *   Downloadvolumen für lange Zeiträume (z.B. 30-Tage-Ansicht) deutlich, da die
+   *   App solche Bereiche ohnehin clientseitig weiter aggregiert (#334). Bereits
+   *   gecachte Tage (z.B. aus Live-Snapshots) werden nicht erneut nachgeladen und
+   *   behalten ihre vorhandene Auflösung.
    */
   async getRange(
     fromTs: number,
     toTs: number,
-    allowServerFallback: boolean = true
+    allowServerFallback: boolean = true,
+    resolution: HistoryResolution = 'raw'
   ): Promise<EnergyData[]> {
     try {
       if (fromTs > toTs) return [];
@@ -334,7 +369,7 @@ export class HistoricalDataStore {
         );
         if (missing.length) {
           for (const d of missing) {
-            await this.loadServerDayIntoStore(d, index);
+            await this.loadServerDayIntoStore(d, index, resolution);
           }
           await this.saveIndex(index);
           index = await this.loadIndex();

--- a/utils/translations.ts
+++ b/utils/translations.ts
@@ -137,6 +137,8 @@ export const translations = {
     shareChartDownload: 'Download Chart',
     // Common actions
     close: 'Close',
+    // Chart Zoom (#355)
+    resetZoom: 'Reset zoom',
     // KPI Row
     renewableNow: 'Renewables now',
     priceNow: 'Price now',
@@ -302,6 +304,8 @@ export const translations = {
     shareChartDownload: 'Diagramm herunterladen',
     // Common actions
     close: 'Schließen',
+    // Chart Zoom (#355)
+    resetZoom: 'Zoom zurücksetzen',
     // KPI Row
     renewableNow: 'Erneuerbare jetzt',
     priceNow: 'Börsenpreis jetzt',


### PR DESCRIPTION
## Beschreibung

Behebt zwei offene UX-/Performance-Issues:

**#355 – Chart-Zoom & Titel-Überlauf**
- `PriceBarChart`, `RenewableBarChart` und `CorrelationScatterChart` (inkl. Detail-Modal via `ChartDetailView`) unterstützen jetzt Pinch-to-Zoom (mobil, über `PanResponder`) bzw. Scroll-to-Zoom (Web, `onWheel`) über einen neuen gemeinsamen Hook `components/charts/shared/useChartZoom.ts`.
  - Die Y-Achsen-Beschriftung bleibt beim horizontalen Scrollen fixiert (aus dem zoombaren `ScrollView`-Content herausgezogen).
  - Ein kleines Reset-Badge (⟲, `ZoomResetBadge.tsx`) erscheint bei aktivem Zoom und setzt Zoom + Scroll-Position zurück.
  - Tooltip-Positionierung berücksichtigt den aktuellen Scroll-Offset (`toViewportX`).
- Chart-Titel brechen jetzt bei Bedarf zweizeilig um (`numberOfLines={2}`, `flex: 1` auf dem Titel-Container) statt auf kleinen Bildschirmen abgeschnitten zu werden.

**#334 – Pre-Aggregierung für Verlaufsdaten**
- Die tägliche History-Pipeline (`fetch.yml`, alle Länder DE/NL/AT/CH/FR/BE/DK) erzeugt jetzt zusätzlich eine stündlich vorab-aggregierte `<date>-hourly.json` Variante (~75% kleiner, verifiziert an echten Beispieldaten: 96 → 24 Punkte) neben der vollen 15-Min-Auflösung.
- `historicalDataStore.getRange()` bekommt einen neuen `resolution`-Parameter (`'raw' | 'hourly'`); `HistoricalDataView` nutzt `'hourly'` für die 30-Tage-Ansicht, da dieser Bereich ohnehin clientseitig auf Tages-Buckets aggregiert dargestellt wird (`dataAggregation.ts`). Automatischer Fallback auf volle Auflösung, falls die stündliche Variante für einen Tag/Land (noch) nicht existiert.
- Bereits gecachte Tage (z.B. aus Live-Snapshots) werden nicht erneut nachgeladen und behalten ihre vorhandene Auflösung – keine Änderung am bestehenden Cache-/Index-/Eviction-Verhalten.

Hinweis: Das ursprünglich in #334 genannte `public/data/archive/` wird zur Laufzeit von der App nicht gelesen (nur Rohdaten-Backup); die tatsächlich von `HistoricalDataView` genutzten Dateien liegen unter `public/data/history/` (Issue #307) – dort wurde die Pre-Aggregierung umgesetzt.

## Art der Änderung

- [x] Neue Funktion (non-breaking change)
- [ ] Bugfix (non-breaking change)
- [ ] Breaking Change
- [ ] Dokumentation Update

## Cross-Platform Kompatibilität

**Betrifft dieser PR plattformspezifischen Code?** Ja

- [x] Zoom-Gesten sind über `Platform.OS === 'web'` verzweigt (`onWheel` Web / `PanResponder` Pinch nativ)
- [x] Keine neuen `window.*`/`document`-Zugriffe außerhalb bestehender Patterns
- [x] Storage-Zugriffe unverändert (`Storage`-Adapter aus `utils/platform.ts`)

### Testing

- [x] Code wurde auf **Web** getestet (Playwright gegen `npm run serve:local`, Screenshots: Scroll-Zoom rein/raus, Reset-Badge, Titel-Umbruch)
- [ ] Code wurde auf **Android** getestet (kein Gerät in dieser Session verfügbar – Pinch-Logik nutzt Standard-`PanResponder`-API, kein neues natives Modul)
- [ ] Code wurde auf **iOS** getestet
- [x] Keine console errors/warnings in Production (Playwright `pageerror`-Listener leer)

## Testing Checklist

- [x] Lokaler Build erfolgreich (`npm run build:local`)
- [x] Keine TypeScript Errors (`tsc --noEmit`)
- [x] Keine neuen ESLint Warnings (nur bestehende `no-inline-styles` Warnungen, konsistent mit dem Rest der Datei)
- [x] App startet ohne Crashes (verifiziert im Browser mit synthetischen Live-Daten)
- [x] Geänderte Features funktionieren wie erwartet (Zoom rein/raus, Reset, Titel-Umbruch)
- [x] Alle 283 bestehenden Jest-Tests grün (inkl. `historicalDataStore.test.ts`)

## Zusätzliche Notizen

- Y-Achsen-Beschriftungen wurden bewusst aus dem zoombaren `ScrollView`-Content herausgezogen (separater, nicht-scrollender Layer), damit sie beim Pannen/Zoomen an Ort und Stelle bleiben.
- `MAX_SCALE = 3`, `MIN_SCALE = 1` in `useChartZoom.ts` – bei Bedarf leicht anpassbar.
- Stats für die 30-Tage-Ansicht basieren bei neu nachgeladenen Tagen künftig auf stündlichen statt 15-Min-Werten (Ø bleibt praktisch identisch, Min/Max leicht geglättet) – bewusster Trade-off, siehe Issue-Beschreibung.

## Reviewer Checklist

- [x] Code folgt den Projekt-Konventionen
- [x] Keine Web APIs ohne Platform-Check
- [x] Keine Hard-coded Values
- [x] Error Handling vorhanden (Fallback auf volle Auflösung bei fehlender `-hourly.json`)
- [x] Keine sensiblen Daten im Code
- [x] Commit Messages sind aussagekräftig

Fixes #355
Fixes #334


---
_Generated by [Claude Code](https://claude.ai/code/session_01JtUntMyypqf1TfazFbZ5bq)_