### PR TITLE
chore: project-templates sync (GLOBAL POLICY + commands)

### DIFF
--- a/.claude/commands/aufräumen.md
+++ b/.claude/commands/aufräumen.md
@@ -15,32 +15,21 @@ for repo in Eisenhauer 1x1_Trainer DrawFromMemory EnergyPriceGermany Pflanzkalen
     ab=$(git rev-list --left-right --count origin/main...origin/testing 2>/dev/null)
     main_ahead=$(echo $ab | awk '{print $1}')
     test_ahead=$(echo $ab | awk '{print $2}')
-    # Phantom-Divergenz ausblenden: nur Nicht-Auto-Commits auf main zählen.
-    # Auto-Commits = extern gezogene Marktdaten o.ä. (marketdata.json, energy-charts,
-    # plant data, "[skip ci]", "chore(data)"). Diese landen per Workflow direkt auf main
-    # und erzeugen sonst Dauer-Divergenz, obwohl inhaltlich nichts auseinanderläuft.
-    real_main_ahead=$(git log --oneline origin/testing..origin/main 2>/dev/null \
-      | grep -vicE 'update marketdata|energy-charts|chore\(data\)|\[skip ci\]|auto-update' )
-    echo "$repo | testing +$test_ahead | main +$main_ahead (echt: $real_main_ahead)"
+    echo "$repo | testing +$test_ahead | main +$main_ahead"
   fi
 done
 ```
 
 Zeige das Ergebnis als Markdown-Tabelle:
 
-| Projekt | testing ahead | main ahead (echt) | Status |
+| Projekt | testing ahead | main ahead | Status |
 |---|---|---|---|
-| ... | ... | ... | ✅ OK / 🔴 Sync-PR nötig |
+| ... | ... | ... | ✅ OK / ⚠️ Divergiert / 🔴 main voraus |
 
-**Statusregeln (auf `real_main_ahead` basieren, NICHT auf `main_ahead`):**
-- ✅ OK — `real_main_ahead = 0` (egal wie viele Auto-Marktdaten-Commits auf main liegen —
-  diese sind erwartet und kein Grund für einen Sync-PR)
-- 🔴 Sync-PR nötig — `real_main_ahead > 0` (echte, nicht-automatische Commits liegen nur auf
-  main und fehlen in testing → `sync: main → testing` PR erstellen)
-
-> **Warum:** Workflows committen extern gezogene Daten (z.B. `marketdata.json`) direkt auf
-> `main`. Ohne Filter meldet der Check Dauer-Divergenz, obwohl nichts Echtes auseinanderläuft.
-> Maßgeblich ist deshalb `real_main_ahead`.
+**Statusregeln:**
+- ✅ OK — main_ahead = 0 (testing enthält main vollständig)
+- ⚠️ Leicht divergiert — main_ahead ≤ 3 und nur Auto-Commits (z.B. marketdata)
+- 🔴 main voraus — main_ahead > 0 mit echten Commits → Sync-PR nötig
 
 ## 1. Repository Status prüfen
 - Prüfe `git status` für uncommitted changes

--- a/.claude/commands/cache-clean.md
+++ b/.claude/commands/cache-clean.md
@@ -1,0 +1,44 @@
+# Lokaler Cache-Cleanup
+
+Führe den lokalen Cache-Cleanup für alle Projekte aus (Festplattenplatz freigeben).
+
+Dies ist ein manueller, seltener Eingriff (kein automatischer Cron) — nur auf
+explizite Anfrage ausführen.
+
+## 1. Report erzeugen (Dry-Run)
+
+Führe im project-templates-Verzeichnis aus:
+
+```bash
+cd "$(find ~/Documents -maxdepth 4 -type d -name project-templates 2>/dev/null | head -1)"
+./scripts/clean-local-cache.sh --dry-run
+```
+
+Zeige das Ergebnis (Größen pro Projekt, geplante Löschungen) als Übersicht.
+
+## 2. Rückfrage
+
+Frage explizit: "Sollen diese Caches gelöscht werden? (node_modules, dist,
+build, .expo, android/.gradle, android/app/build)"
+
+Bei Zustimmung:
+
+```bash
+./scripts/clean-local-cache.sh --yes
+```
+
+## 3. Optional: globale Caches
+
+Frage separat: "Auch globale Caches leeren? (~/.gradle/caches ~9GB, ~/.npm
+~900MB — betrifft alle Gradle-/Node-Projekte gemeinsam)"
+
+Bei Zustimmung:
+
+```bash
+./scripts/clean-local-cache.sh --yes --global
+```
+
+## 4. Hinweis nach dem Löschen
+
+Erinnere daran, dass beim nächsten Start des jeweiligen Projekts
+`npm install` (und ggf. `npx expo prebuild` / Gradle-Sync) nötig ist.

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -52,21 +52,27 @@ Einen Pull Request gründlich prüfen, Code-Review-Suggestions umsetzen und für
 - Falls neue Features/Breaking Changes: Schlage CHANGELOG-Eintrag vor
 - Prüfe ob README/Docs aktualisiert werden müssen
 
-### 6. Merge-Gate (review-gate) – automatischer Claude-Review + Autofix
+### 6. Merge-Gate (review-gate) + KI-Review
 
-Der Workflow `reusable-pr-review.yml` korrigiert den PR automatisch und reviewt
-den End-Stand, dann setzt er den required Status-Check **`review-gate`** und ein Label:
+**Kostenloses Gate (automatisch, keine API-Kosten):** Der Workflow
+`reusable-mergeability.yml` läuft bei jedem PR, postet einen Sticky-Kommentar
+(Zielbranch, Konflikt-Status, CI-Übersicht, Checkliste) und setzt den required
+Status-Check **`review-gate`**:
+- **kein Merge-Konflikt → grün** → Merge möglich (sofern auch CI grün ist).
+- **Merge-Konflikt → rot** → Branch aktualisieren.
 
-1. **Autofix:** Ein Claude-Agent fixt alle umsetzbaren Findings selbst (Commit `[auto]` + Push).
-2. **Review:** bewertet den korrigierten Stand:
-   - **Keine offenen Findings → grün** + Label `ready to merge` → Merge frei.
-   - **Findings übrig → rot** + Inline-Kommentare + Label `needs human review`.
+**Tiefer KI-Review (primärer Weg, abo-basiert, ohne Pay-per-Token):** Führe das
+Slash-Command `/review` (bzw. `/code-review --comment`) aus Claude Code aus —
+lokal am PC **oder** in einer Web-Session vom Telefon. Das ist durch dein
+Pro/Max-Abo gedeckt und kostet keine metered API-Token. Mit `--comment` werden die
+Findings als PR-Kommentare gepostet, mit `--fix` direkt im Working-Tree umgesetzt.
 
-Bei `needs human review`: Findings lesen, klären/umsetzen, pushen → frischer Lauf.
+**Optionaler API-Fallback (kostet metered API):** Setze das Label **`ai-review`**
+am PR → `pr-review.yml` postet einen beratenden Claude-Review (Haiku). Dieser
+blockiert den Merge **nicht** — er ergänzt nur das kostenlose Gate.
 
-> ⚠️ Es gibt **kein** manuelles Quittierungs-Label mehr. Den roten Gate öffnet nur
-> ein sauberer Review (alle Findings gelöst). Solange `needs human review` gesetzt
-> ist: **nicht mergen**, bis die offenen Punkte geklärt sind.
+> ℹ️ Der KI-Review ist beratend; verbindlich für den Merge sind die kostenlosen,
+> deterministischen Checks (CI grün + `review-gate` grün + keine Konflikte).
 
 ### 7. Merge vorbereiten
 - Prüfe ob alle Checks grün sind (inkl. `review-gate`)
@@ -129,7 +135,7 @@ Bei `needs human review`: Findings lesen, klären/umsetzen, pushen → frischer 
 **KRITISCH - NIEMALS automatisch mergen wenn:**
 - ❌ CI/CD Tests fehlgeschlagen
 - ❌ Merge Conflicts vorhanden
-- ❌ `review-gate` ist rot bzw. Label `needs human review` gesetzt (offene Findings erst klären)
+- ❌ `review-gate` ist rot (Merge-Konflikt – erst Branch aktualisieren)
 - ❌ Target-Branch ist `main` oder `production` (extra Vorsicht, nur mit Freigabe + `--admin`)
 
 **Immer fragen vor:**

--- a/.claude/commands/security-review.md
+++ b/.claude/commands/security-review.md
@@ -1,0 +1,58 @@
+# Security Review (Cross-Project)
+
+Globaler Security-Scan über alle lokalen Projekte mit konsolidiertem Report (Issue #7).
+
+> **Ablageort:** global unter `~/.claude/commands/security-review.md`, nicht pro Projekt.
+> Begründung: scannt projektübergreifend, gehört nicht in ein einzelnes Repo.
+
+## Ziel
+Alle lokalen Projekt-Repositories auf Secrets, Fingerprints, getrackte sensible Dateien
+und Gitignore-Lücken prüfen – ein zusammengefasster Bericht statt sieben Einzelläufe.
+
+## Workflow
+
+### 1. Projekte ermitteln
+- Bestimme die zu prüfenden Repos (Standard: alle App-Projekte im Workspace).
+- Pro Repo: ist es ein Git-Repo? Aktueller Branch? Uncommitted Changes?
+
+### 2. Pro Projekt scannen
+Für jedes Repo dieselben Checks (entsprechen `reusable-security-scan.yml`):
+
+- **Signing-Fingerprints** (SHA1/SHA256 Colon-Hex):
+  ```bash
+  git -C "$repo" grep -nE '([0-9A-Fa-f]{2}:){15,}[0-9A-Fa-f]{2}' -- . ':!*.lock'
+  ```
+- **Hardcodierte API-Keys / Tokens:**
+  ```bash
+  git -C "$repo" grep -niE '(api[_-]?key|secret[_-]?key|auth[_-]?token|access[_-]?token)["'\'' ]*[:=]["'\'' ]*[A-Za-z0-9_-]{16,}' -- . ':!*.lock'
+  ```
+- **Getrackte sensible Dateien:** (nur konventionell-geheime .env – nicht committete `.env.<environment>`-Config)
+  ```bash
+  git -C "$repo" ls-files | grep -E '(credentials\.json$|\.jks$|\.keystore$|\.p12$|\.p8$|(^|/)\.env(\.local)?$|(^|/)\.env\.[^/]*\.local$)'
+  ```
+- **Gitignore-Pflichteinträge** vorhanden? (`.env`, `.env.local`, `credentials.json`, `*.jks`, `*.keystore`, `*.p12`, `*.p8`, `docs/private/`) – deckungsgleich mit `reusable-gitignore-audit.yml`. `.env.<environment>` mit reiner Public-Config ist erlaubt.
+- **`docs/private/` nicht getrackt?**
+- **`npm audit`** (falls `package.json` vorhanden) – Vulnerabilities zählen.
+
+### 3. Befunde einordnen
+- Bekannte False Positives kennzeichnen (z.B. CrUX-Demo-Key in `@react-native/debugger-frontend`).
+- Severity zuordnen: 🔴 Secret/Fingerprint getrackt · 🟡 Gitignore-Lücke · 🟢 nur Hinweis.
+
+### 4. Konsolidierter Report
+Tabelle über alle Projekte:
+
+| Projekt | Fingerprints | Secrets | Sensible Dateien | Gitignore | npm audit |
+|---|---|---|---|---|---|
+| ... | ✅/❌ | ✅/❌ | ✅/❌ | ✅/⚠️ | 0 / N |
+
+- Anschließend priorisierte Handlungsempfehlungen (kritischste zuerst).
+- Nichts automatisch ändern – nur berichten und Fixes vorschlagen.
+
+## Sicherheitschecks
+- **Niemals** gefundene Secrets im Klartext in Commits/Issues/Logs ausgeben – nur Datei + Zeile.
+- Bei echtem Leak: sofort als kritisch markieren, Rotation + History-Bereinigung empfehlen.
+
+## Best Practices
+✅ Regelmäßig laufen lassen (z.B. wöchentlich, ergänzend zu `weekly-audit.yml`).
+✅ Public-Repos strenger behandeln (alle Workspace-Projekte sind öffentlich).
+❌ Keine destruktiven Aktionen ohne Rückfrage (kein `git filter-repo` etc. automatisch).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -448,3 +448,31 @@ cd android && ./gradlew bundleRelease --no-daemon
 ## Questions?
 Refer to documentation in root directory or check GitHub issues:
 - [GitHub Issues](https://github.com/S540d/Energy_Price_Germany/issues)
+
+<!-- GLOBAL POLICY:START -->
+## [GLOBAL POLICY]
+
+> Automatisch synchronisiert aus project-templates (Issue #7). Nicht manuell editieren –
+> Änderungen hier werden beim nächsten Sync überschrieben. Quelle anpassen statt lokal.
+
+- PRs immer gegen `testing`, nie direkt gegen `staging` oder `main`
+- Merge auf `main` nur mit expliziter schriftlicher Freigabe
+- `--delete-branch` nur für Feature-Branches (nie staging/testing)
+- **Lokales Branch-Cleanup:** `main` und `testing` NIE löschen — auch nicht beim Bulk-Delete verwaister `[gone]`-Branches. Ein fehlender `origin/main`/`origin/testing` ist ein **wiederherzustellender Defekt** (lokal behalten, nach origin zurückpushen), kein Aufräum-Signal.
+- `--no-verify` nur auf explizite Bitte
+- **Vor jedem Push: lokale Tests ausführen** (`npm test` bzw. projektspezifischer Test-Befehl) – kein Push ohne grüne lokale Tests
+- **Kein Merge bei CI-Fail** – Branch Protection erzwingt das technisch; nie mit `--admin` umgehen außer auf explizite Bitte
+
+## [ANDROID BUILD – PFLICHTREGELN]
+
+- **Git-Tag** nach jedem Play-Store-Upload setzen: `git tag vX.Y.Z && git push origin vX.Y.Z` – der Tag markiert den tatsächlich veröffentlichten Stand und dient als Changelog-Baseline für den nächsten Build
+- **EAS Local Build (DrawFromMemory):** Workingdir vor jedem Build leeren: `rm -rf ~/tmp/eas-build && mkdir -p ~/tmp/eas-build` – ein nicht-leeres Verzeichnis bricht den Build sofort ab
+- **Disk-Check vor EAS Build:** Skia-Libraries benötigen ~5–8 GB. Bei < 5 GB frei: `npm cache clean --force && rm -rf ~/.npm/_npx` (~13 GB, sicher löschbar)
+- **JAVA_HOME** für EAS/Expo-Builds explizit auf Android Studio JBR setzen: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`
+- **Gradle-Lock nach Absturz:** Bei "Cannot lock file hash cache"-Fehler Daemons stoppen: `pkill -f GradleDaemon`, dann Workingdir leeren und neu starten
+- **AAB-Archiv:** Gebaute Release-AABs in einem **gitignored** `aab-archive/`-Verzeichnis im Repo-Root ablegen (in `.gitignore` aufnehmen – AABs sind 3–110 MB und gehören nie in die Git-History). Benennung: `<Projekt>-vX.Y.Z-vc<versionCode>-YYYY-MM-DD.aab`. **Retention: max. 2 Dateien** (aktuelles Release + ein Vorgänger für schnelles Rollback); ältere AABs löschen. Der Git-Tag `vX.Y.Z` ist die eigentliche Release-Baseline – ältere AABs lassen sich daraus jederzeit neu bauen.
+
+## [CI – CACHE-CLEANUP]
+
+- **Cache-Cleanup-Workflow** (`.github/workflows/cache-cleanup.yml`) in jedem Repo mit GitHub-Actions-Caches: löscht wöchentlich (So 03:00 UTC) bzw. on-demand alle Action-Caches älter als der jeweils letzte Lauf. GitHub-Limit ist 10 GB pro Repo – ohne Cleanup laufen Build-Caches (node_modules, Gradle, Expo) voll und verdrängen frische Einträge. Vorlage: `cache-cleanup.yml` in project-templates.
+<!-- GLOBAL POLICY:END -->


### PR DESCRIPTION
## Was

Synchronisiert `.claude/commands/` und den `CLAUDE.md` GLOBAL POLICY Block aus project-templates.

## Bewusst NICHT übernommen

`.prettierrc.json`: eigene, abweichende Config bleibt bestehen — kein Reformatieren ohne funktionalen Nutzen.

## Tests

- `npm test`: 283/283 grün
- `npm run format:check`: sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)