### PR TITLE
Komponententests für PriceBarChart, RenewableBarChart, CorrelationScatterChart

### DIFF
--- a/__mocks__/react-native-svg.js
+++ b/__mocks__/react-native-svg.js
@@ -1,0 +1,49 @@
+// Manual Jest mock for react-native-svg (RNTL/jsdom can't run its native bridge).
+// Renders every primitive as a plain View so charts stay testable; SVG-only
+// props (x1/y1/points/...) just pass through as inert view props.
+const React = require('react');
+const { View } = require('react-native');
+
+function makePrimitive(displayName) {
+  const Component = React.forwardRef((props, ref) =>
+    React.createElement(View, { ...props, ref, testID: props.testID ?? displayName })
+  );
+  Component.displayName = displayName;
+  return Component;
+}
+
+const Svg = makePrimitive('Svg');
+const Rect = makePrimitive('Rect');
+const Circle = makePrimitive('Circle');
+const Line = makePrimitive('Line');
+const Path = makePrimitive('Path');
+const Polyline = makePrimitive('Polyline');
+const Polygon = makePrimitive('Polygon');
+const G = makePrimitive('G');
+const Text = makePrimitive('SvgText');
+const Defs = makePrimitive('Defs');
+const Stop = makePrimitive('Stop');
+const LinearGradient = makePrimitive('LinearGradient');
+const RadialGradient = makePrimitive('RadialGradient');
+const ClipPath = makePrimitive('ClipPath');
+const Ellipse = makePrimitive('Ellipse');
+
+module.exports = {
+  __esModule: true,
+  default: Svg,
+  Svg,
+  Rect,
+  Circle,
+  Line,
+  Path,
+  Polyline,
+  Polygon,
+  G,
+  Text,
+  Defs,
+  Stop,
+  LinearGradient,
+  RadialGradient,
+  ClipPath,
+  Ellipse,
+};

--- a/components/charts/__tests__/CorrelationScatterChart.test.tsx
+++ b/components/charts/__tests__/CorrelationScatterChart.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * CorrelationScatterChart Tests
+ * Rendering, guard clauses (degenerate regression inputs) for the scatter chart.
+ */
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import { CorrelationScatterChart } from '../CorrelationScatterChart';
+import { LanguageProvider } from '../../../context/LanguageContext';
+import { getThemeColors } from '../../../utils/theme';
+
+const colors = getThemeColors('light', 'light');
+
+const labels = {
+  yAxisPrice: 'ct/kWh',
+  xAxisRenewables: '% Erneuerbare',
+  night: 'Nacht',
+  morningEvening: 'Morgen/Abend',
+  day: 'Tag',
+};
+
+const baseTime = new Date('2026-01-01T00:00:00Z').getTime();
+const hour = 60 * 60 * 1000;
+
+// Varying price and renewable share so the linear regression isn't degenerate
+// (constant renewableShare across all points makes the regression denominator 0,
+// and constant marketPrice collapses priceRange to 0 — both are guarded null-returns).
+function buildData(count: number) {
+  return Array.from({ length: count }, (_, i) => ({
+    timestamp: baseTime + i * hour,
+    marketPrice: 200 + (i % 5) * 10,
+    renewableShare: 20 + i * 3,
+    isMarketPriceInterpolated: false,
+    isRenewableShareInterpolated: false,
+  }));
+}
+
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <LanguageProvider>{children}</LanguageProvider>
+);
+
+function renderChart(props: Partial<React.ComponentProps<typeof CorrelationScatterChart>> = {}) {
+  return render(
+    <TestWrapper>
+      <CorrelationScatterChart
+        title="Korrelation"
+        data={buildData(24)}
+        backgroundColor={colors.surface}
+        textColor={colors.text}
+        gridColor={colors.gridLine}
+        colors={colors}
+        labels={labels}
+        {...props}
+      />
+    </TestWrapper>
+  );
+}
+
+describe('CorrelationScatterChart', () => {
+  it('renders without crashing for a normal dataset', async () => {
+    const { UNSAFE_root } = renderChart();
+    await waitFor(() => {
+      expect(UNSAFE_root).toBeTruthy();
+    });
+  });
+
+  it('renders the title', async () => {
+    const { getByText } = renderChart();
+    await waitFor(() => {
+      expect(getByText('Korrelation')).toBeTruthy();
+    });
+  });
+
+  it('returns null (no crash) for an empty dataset', () => {
+    const { toJSON } = renderChart({ data: [] });
+    expect(toJSON()).toBeNull();
+  });
+
+  it('returns null (no crash) when every point is interpolated', () => {
+    const data = buildData(10).map(d => ({ ...d, isMarketPriceInterpolated: true }));
+    const { toJSON } = renderChart({ data });
+    expect(toJSON()).toBeNull();
+  });
+
+  it('returns null (no crash) when marketPrice is constant (degenerate price range)', () => {
+    const data = buildData(10).map(d => ({ ...d, marketPrice: 200 }));
+    const { toJSON } = renderChart({ data });
+    expect(toJSON()).toBeNull();
+  });
+
+  it('returns null (no crash) when renewableShare is constant (degenerate regression)', () => {
+    const data = buildData(10).map(d => ({ ...d, renewableShare: 50 }));
+    const { toJSON } = renderChart({ data });
+    expect(toJSON()).toBeNull();
+  });
+
+  it('does not throw for a single valid data point', () => {
+    const data = [buildData(1)[0]];
+    expect(() => renderChart({ data })).not.toThrow();
+  });
+});

--- a/components/charts/__tests__/PriceBarChart.test.tsx
+++ b/components/charts/__tests__/PriceBarChart.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * PriceBarChart Tests
+ * Rendering, guard clauses and coordinate-consistency for the price chart.
+ */
+
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { PriceBarChart } from '../PriceBarChart';
+import { LanguageProvider } from '../../../context/LanguageContext';
+import { SettingsProvider } from '../../../context/SettingsContext';
+import { getThemeColors } from '../../../utils/theme';
+
+const colors = getThemeColors('light', 'light');
+
+const labels = {
+  yAxis: 'ct/kWh',
+  now: 'Jetzt',
+  average: 'Ø',
+  marketPrice: 'Marktpreis',
+  gridFeesAndTaxes: 'Netzentgelte',
+  interpolated: 'Interpoliert',
+  tooltipMarketPrice: 'Marktpreis',
+  tooltipGridFees: 'Netzentgelte',
+  tooltipEndCustomer: 'Gesamtpreis',
+};
+
+const baseTime = new Date('2026-01-01T00:00:00Z').getTime();
+const hour = 60 * 60 * 1000;
+
+function buildData(
+  count: number,
+  overrides?: (i: number) => Partial<{ marketPrice: number | null }>
+) {
+  return Array.from({ length: count }, (_, i) => ({
+    timestamp: baseTime + i * hour,
+    marketPrice: 20 + i,
+    renewableShare: 50,
+    isMarketPriceInterpolated: false,
+    ...(overrides ? overrides(i) : {}),
+  }));
+}
+
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <SettingsProvider>
+    <LanguageProvider>{children}</LanguageProvider>
+  </SettingsProvider>
+);
+
+function renderChart(props: Partial<React.ComponentProps<typeof PriceBarChart>> = {}) {
+  return render(
+    <TestWrapper>
+      <PriceBarChart
+        title="Strompreis"
+        data={buildData(24)}
+        backgroundColor={colors.surface}
+        textColor={colors.text}
+        gridColor={colors.gridLine}
+        colors={colors}
+        labels={labels}
+        {...props}
+      />
+    </TestWrapper>
+  );
+}
+
+describe('PriceBarChart', () => {
+  it('renders without crashing for a normal dataset', async () => {
+    const { UNSAFE_root } = renderChart();
+    await waitFor(() => {
+      expect(UNSAFE_root).toBeTruthy();
+    });
+  });
+
+  it('renders the title and average label', async () => {
+    const { getByText } = renderChart();
+    await waitFor(() => {
+      expect(getByText('Strompreis')).toBeTruthy();
+    });
+    expect(getByText(/Ø/)).toBeTruthy();
+  });
+
+  it('returns null (no crash) for an empty dataset', () => {
+    const { toJSON } = renderChart({ data: [] });
+    expect(toJSON()).toBeNull();
+  });
+
+  it('returns null (no crash) when every data point has a null market price', () => {
+    const data = buildData(5, () => ({ marketPrice: null }));
+    const { toJSON } = renderChart({ data });
+    expect(toJSON()).toBeNull();
+  });
+
+  it('returns null (no crash) for a single data point (degenerate time range)', () => {
+    const data = [buildData(1)[0]];
+    const { toJSON } = renderChart({ data });
+    expect(toJSON()).toBeNull();
+  });
+
+  it('does not throw when all timestamps are identical', () => {
+    const data = buildData(5).map(d => ({ ...d, timestamp: baseTime }));
+    expect(() => renderChart({ data })).not.toThrow();
+  });
+
+  it('shows the tooltip for the selected bar without throwing', async () => {
+    const { UNSAFE_root, getByText } = renderChart();
+    const touchables = UNSAFE_root.findAll(
+      (node: { props: Record<string, unknown> }) =>
+        typeof node.props.onResponderGrant === 'function'
+    );
+    expect(touchables.length).toBeGreaterThan(0);
+
+    fireEvent(touchables[0], 'responderGrant');
+
+    await waitFor(() => {
+      expect(getByText('Gesamtpreis')).toBeTruthy();
+    });
+  });
+
+  it('renders a dashed placeholder instead of crashing when a bar has a null market price', async () => {
+    const data = buildData(10, i => (i === 3 ? { marketPrice: null } : {}));
+    const { UNSAFE_root } = renderChart({ data });
+    await waitFor(() => {
+      expect(UNSAFE_root).toBeTruthy();
+    });
+  });
+
+  it('respects showLegend=false (regression guard for ChartSection usage)', async () => {
+    const { queryByText } = renderChart({ showLegend: false });
+    await waitFor(() => {
+      expect(queryByText('Marktpreis')).toBeNull();
+    });
+  });
+});

--- a/components/charts/__tests__/RenewableBarChart.test.tsx
+++ b/components/charts/__tests__/RenewableBarChart.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * RenewableBarChart Tests
+ * Rendering, guard clauses and >100% split-bar handling for the renewables chart.
+ */
+
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { RenewableBarChart } from '../RenewableBarChart';
+import { LanguageProvider } from '../../../context/LanguageContext';
+import { getThemeColors } from '../../../utils/theme';
+
+const colors = getThemeColors('light', 'light');
+
+const labels = {
+  yAxis: '%',
+  now: 'Jetzt',
+  average: 'Ø',
+  regional: 'Regional',
+};
+
+const baseTime = new Date('2026-01-01T00:00:00Z').getTime();
+const hour = 60 * 60 * 1000;
+
+function buildData(
+  count: number,
+  overrides?: (
+    i: number
+  ) => Partial<{ renewableShare: number | null; renewableShareRegional: number | null }>
+) {
+  return Array.from({ length: count }, (_, i) => ({
+    timestamp: baseTime + i * hour,
+    marketPrice: 20,
+    renewableShare: 50,
+    isRenewableShareInterpolated: false,
+    ...(overrides ? overrides(i) : {}),
+  }));
+}
+
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <LanguageProvider>{children}</LanguageProvider>
+);
+
+function renderChart(props: Partial<React.ComponentProps<typeof RenewableBarChart>> = {}) {
+  return render(
+    <TestWrapper>
+      <RenewableBarChart
+        title="Erneuerbare"
+        data={buildData(24)}
+        backgroundColor={colors.surface}
+        textColor={colors.text}
+        gridColor={colors.gridLine}
+        colors={colors}
+        labels={labels}
+        {...props}
+      />
+    </TestWrapper>
+  );
+}
+
+describe('RenewableBarChart', () => {
+  it('renders without crashing for a normal dataset', async () => {
+    const { UNSAFE_root } = renderChart();
+    await waitFor(() => {
+      expect(UNSAFE_root).toBeTruthy();
+    });
+  });
+
+  it('renders the title', async () => {
+    const { getByText } = renderChart();
+    await waitFor(() => {
+      expect(getByText('Erneuerbare')).toBeTruthy();
+    });
+  });
+
+  it('returns null (no crash) for an empty dataset', () => {
+    const { toJSON } = renderChart({ data: [] });
+    expect(toJSON()).toBeNull();
+  });
+
+  it('does not throw when every value is null (falls back to a default average)', async () => {
+    const data = buildData(5, () => ({ renewableShare: null }));
+    const { UNSAFE_root } = renderChart({ data });
+    await waitFor(() => {
+      expect(UNSAFE_root).toBeTruthy();
+    });
+  });
+
+  it('does not throw for values above 100% (split-bar rendering)', async () => {
+    const data = buildData(10, i => (i === 2 ? { renewableShare: 130 } : {}));
+    const { UNSAFE_root } = renderChart({ data });
+    await waitFor(() => {
+      expect(UNSAFE_root).toBeTruthy();
+    });
+  });
+
+  it('does not throw when all timestamps are identical', () => {
+    const data = buildData(5).map(d => ({ ...d, timestamp: baseTime }));
+    expect(() => renderChart({ data })).not.toThrow();
+  });
+
+  it('renders the regional dashed line without throwing when enabled', async () => {
+    const data = buildData(10, i => ({ renewableShareRegional: 40 + i }));
+    const { UNSAFE_root } = renderChart({ data, showRegionalLine: true });
+    await waitFor(() => {
+      expect(UNSAFE_root).toBeTruthy();
+    });
+  });
+
+  it('does not throw when regional values are missing while showRegionalLine is set', async () => {
+    const data = buildData(10, () => ({ renewableShareRegional: null }));
+    const { UNSAFE_root } = renderChart({ data, showRegionalLine: true });
+    await waitFor(() => {
+      expect(UNSAFE_root).toBeTruthy();
+    });
+  });
+
+  it('shows the tooltip for the selected bar without throwing', async () => {
+    const { UNSAFE_root, getByText } = renderChart();
+    const touchables = UNSAFE_root.findAll(
+      (node: { props: Record<string, unknown> }) =>
+        typeof node.props.onResponderGrant === 'function'
+    );
+    expect(touchables.length).toBeGreaterThan(0);
+
+    fireEvent(touchables[0], 'responderGrant');
+
+    await waitFor(() => {
+      expect(getByText('50.0%')).toBeTruthy();
+    });
+  });
+
+  it('supports the renewableShareRegional dataKey without throwing', async () => {
+    const data = buildData(10, i => ({ renewableShareRegional: 30 + i }));
+    const { UNSAFE_root } = renderChart({ data, dataKey: 'renewableShareRegional' });
+    await waitFor(() => {
+      expect(UNSAFE_root).toBeTruthy();
+    });
+  });
+});

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -77,6 +77,9 @@ jest.mock('react-native', () => ({
     getPixelSizeForLayoutSize: jest.fn((size) => size * 2),
     roundToNearestPixel: jest.fn((size) => size),
   },
+  PanResponder: {
+    create: jest.fn(() => ({ panHandlers: {} })),
+  },
 }));
 
 // Mock AsyncStorage


### PR DESCRIPTION
# Pull Request

## Beschreibung

Zweiter Teil der Codepflege-Runde aus PR #389: dort war aufgefallen, dass die drei SVG-Chart-Komponenten keine eigenen Render-Tests haben — genau deshalb war der dort behobene Tooltip-Offset-Bug (fehlendes `rightPadding`) jahrelang unbemerkt geblieben. Dieser PR schließt die Lücke.

**Warum es bisher keine Chart-Tests gab:** `react-native-svg` lädt unter der jsdom-basierten Jest-Umgebung dieses Projekts nicht (`TypeError: Cannot read properties of undefined (reading 'Mixin')` beim Import). Die Komponenten waren dadurch schlicht nicht testbar, unabhängig vom Testinhalt.

**Testinfrastruktur (musste einmalig ergänzt werden):**
- `__mocks__/react-native-svg.js`: neuer manueller Jest-Mock, rendert alle verwendeten SVG-Primitive (`Svg`, `Rect`, `Circle`, `Line`, `Path`, `Polyline`, `G`, `Text as SvgText`, ...) als einfache `View`s.
- `jest.setup.js`: `PanResponder` zum bereits bestehenden zentralen `react-native`-Mock ergänzt. `useChartZoom` (Pinch/Scroll-Zoom, #355/#380) ruft `PanResponder.create()` unabhängig von der Plattform auf, aber das projektweite RN-Mock-Objekt exportierte `PanResponder` bisher nicht — jede Komponente, die den Zoom-Hook nutzt, crashte dadurch unter Test. Ergänzt um einen No-op (`{ create: () => ({ panHandlers: {} }) }`), passend zum bestehenden Muster der anderen RN-Mocks in derselben Datei.

Beide Ergänzungen sind rein additiv und global (nicht auf einzelne Testdateien beschränkt), damit künftige Chart- oder Zoom-bezogene Tests direkt darauf aufbauen können.

**26 neue Tests über 3 Suiten** (`components/charts/__tests__/`), Fokus auf:
- Rendering ohne Crash mit realistischen Daten (Titel, Legende, Achsen)
- Guard-Klauseln: leere Daten, durchgängig `null`-Werte, einzelner Datenpunkt, identische Zeitstempel/Werte → degenerierter Wertebereich (genau die Fälle, die `chartScale.ts` aus PR #389 gegen `NaN` absichert)
- `CorrelationScatterChart`: entartete lineare Regression (konstanter Preis bzw. konstanter Erneuerbaren-Anteil → Nenner bzw. Preisspanne wird 0)
- Tooltip-Interaktion: Balken auswählen (`responderGrant`), Tooltip-Inhalt prüfen
- `RenewableBarChart`: >100 %-Split-Bar-Darstellung, regionale Vergleichslinie, alternativer `dataKey`

## Art der Änderung

- [ ] Bugfix (non-breaking change)
- [ ] Neue Funktion (non-breaking change)
- [ ] Breaking Change (Fix oder Feature das bestehende Funktionalität ändert)
- [x] Dokumentation Update (nein — aber am ehesten hier passend: Test-/Tooling-Ergänzung ohne Produktionscode-Änderung)

## Cross-Platform Kompatibilität

**Betrifft dieser PR plattformspezifischen Code?** Nein

Reine Test- und Jest-Mock-Ergänzungen. Kein Produktionscode geändert.

## Testing Checklist

- [x] Keine TypeScript Errors (`npx tsc --noEmit` sauber)
- [x] Keine ESLint Errors (`npx eslint .` → 0 Errors; 267 vorbestehende Warnings unverändert)
- [x] Testsuite grün: **25 Suiten / 306 Tests** (vorher 22 Suiten / 280 Tests)
- [ ] Lokaler Build (`npm run build:web`) – nicht ausgeführt
- [ ] Manuell auf Web/Android getestet – nicht anwendbar (keine Produktionscode-Änderung)

## Screenshots / Videos

Keine – reine Testergänzung, keine sichtbaren Änderungen.

## Zusätzliche Notizen

**Bewusst nicht in diesem PR:** `ClockChart.tsx` (viertes Chart, alternative Uhr-Darstellung) ist noch ungetestet — gleiches Testmuster ließe sich übertragen, war aber nicht Teil des ursprünglichen Audit-Befunds zu den drei Haupt-Charts.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LL9SZKyugnbvwGv3ng16TU)_