### PR TITLE
ClockChart-Tests + alle ESLint-Warnings beheben (267 → 0)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -38,6 +38,7 @@ import {
 SplashScreenModule.preventAutoHideAsync().catch(() => {});
 
 const APP_VERSION = '1.9.0';
+const TRANSPARENT = 'transparent';
 
 function AppContent() {
   const [showSplash, setShowSplash] = useState(true);
@@ -284,7 +285,7 @@ function AppContent() {
           <LinearGradient
             colors={['#0a0f1e', '#0d1a2e', '#0a1628']}
             locations={[0, 0.5, 1]}
-            style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}
+            style={StyleSheet.absoluteFill}
             pointerEvents="none"
           />
         )}
@@ -314,15 +315,11 @@ function AppContent() {
         <CustomizeModal visible={customizeVisible} onClose={() => setCustomizeVisible(false)} />
 
         <ScrollView
-          style={[
-            styles.scrollView,
-            { backgroundColor: isDark ? 'transparent' : colors.background },
+          style={[styles.scrollView, { backgroundColor: isDark ? TRANSPARENT : colors.background }]}
+          contentContainerStyle={[
+            styles.scrollContentBase,
+            { backgroundColor: isDark ? TRANSPARENT : colors.background },
           ]}
-          contentContainerStyle={{
-            flexGrow: 1,
-            backgroundColor: isDark ? 'transparent' : colors.background,
-            paddingBottom: 20,
-          }}
           bounces={false}
         >
           <ChartSection
@@ -382,6 +379,13 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
   },
+  scrollContentBase: {
+    flexGrow: 1,
+    paddingBottom: 20,
+  },
+  safeAreaProvider: {
+    flex: 1,
+  },
   skeletonScroll: {
     flexGrow: 1,
   },
@@ -403,7 +407,7 @@ import { CountryProvider } from './context/CountryContext';
 
 export default function App() {
   return (
-    <SafeAreaProvider style={{ flex: 1 }}>
+    <SafeAreaProvider style={styles.safeAreaProvider}>
       <LanguageProvider>
         <CountryProvider>
           <SettingsProvider>

--- a/components/AboutView.tsx
+++ b/components/AboutView.tsx
@@ -105,9 +105,7 @@ export function AboutView({
             <Text style={[styles.infoText, { color: colors.textSecondary }]}>
               License: CC BY 4.0
             </Text>
-            <Text
-              style={[styles.infoText, { color: colors.textSecondary, fontSize: 12, marginTop: 4 }]}
-            >
+            <Text style={[styles.infoTextSmall, { color: colors.textSecondary }]}>
               Regional renewable energy share based on postal code (PLZ).
             </Text>
             <TouchableOpacity
@@ -133,12 +131,7 @@ export function AboutView({
             <Text style={[styles.infoText, { color: colors.textSecondary }]}>
               Open Source • MIT License
             </Text>
-            <Text
-              style={[
-                styles.infoText,
-                { color: colors.textSecondary, fontSize: 12, fontStyle: 'italic', marginTop: 4 },
-              ]}
-            >
+            <Text style={[styles.infoTextSmallItalic, { color: colors.textSecondary }]}>
               {t.noCommercialUse}
             </Text>
             <TouchableOpacity
@@ -227,7 +220,7 @@ export function AboutView({
           </View>
 
           {/* Credits */}
-          <View style={[styles.section, { paddingBottom: 40 }]} />
+          <View style={styles.footerSpacer} />
         </ScrollView>
       </View>
     </Modal>
@@ -264,6 +257,10 @@ const styles = StyleSheet.create({
   section: {
     marginBottom: 24,
   },
+  footerSpacer: {
+    marginBottom: 24,
+    paddingBottom: 40,
+  },
   sectionTitle: {
     fontSize: 16,
     fontWeight: '600',
@@ -273,6 +270,15 @@ const styles = StyleSheet.create({
     fontSize: 14,
     lineHeight: 20,
     marginBottom: 4,
+  },
+  infoTextSmall: {
+    fontSize: 12,
+    marginTop: 4,
+  },
+  infoTextSmallItalic: {
+    fontSize: 12,
+    fontStyle: 'italic',
+    marginTop: 4,
   },
   link: {
     marginTop: 8,

--- a/components/ApplianceTimeline.tsx
+++ b/components/ApplianceTimeline.tsx
@@ -282,10 +282,9 @@ function ApplianceTimelineComponent({ appliances, priceData, gridFees }: Applian
                         key={`gap-${col.hours[0]}`}
                         style={[
                           styles.gapCell,
+                          anyInWindow && styles.windowBorder,
                           anyInWindow && {
                             backgroundColor: `${colors.success}30`,
-                            borderTopWidth: 2,
-                            borderBottomWidth: 2,
                             borderColor: colors.success,
                           },
                         ]}
@@ -319,22 +318,13 @@ function ApplianceTimelineComponent({ appliances, priceData, gridFees }: Applian
                       key={`h-${col.slot.hour}-${ci}`}
                       style={[
                         styles.hourCell,
+                        inWindow && styles.windowBorder,
                         inWindow && {
                           backgroundColor: `${colors.success}30`,
-                          borderTopWidth: 2,
-                          borderBottomWidth: 2,
                           borderColor: colors.success,
                         },
-                        roundLeft && {
-                          borderLeftWidth: 2,
-                          borderTopLeftRadius: 6,
-                          borderBottomLeftRadius: 6,
-                        },
-                        roundRight && {
-                          borderRightWidth: 2,
-                          borderTopRightRadius: 6,
-                          borderBottomRightRadius: 6,
-                        },
+                        roundLeft && styles.windowRoundLeft,
+                        roundRight && styles.windowRoundRight,
                       ]}
                     />
                   );
@@ -359,11 +349,7 @@ function ApplianceTimelineComponent({ appliances, priceData, gridFees }: Applian
             <View
               style={[
                 styles.legendDot,
-                {
-                  backgroundColor: `${colors.success}30`,
-                  borderColor: colors.success,
-                  borderWidth: 1.5,
-                },
+                { backgroundColor: `${colors.success}30`, borderColor: colors.success },
               ]}
             />
             <Text style={[styles.legendText, { color: colors.textSecondary }]}>
@@ -427,6 +413,20 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  windowBorder: {
+    borderTopWidth: 2,
+    borderBottomWidth: 2,
+  },
+  windowRoundLeft: {
+    borderLeftWidth: 2,
+    borderTopLeftRadius: 6,
+    borderBottomLeftRadius: 6,
+  },
+  windowRoundRight: {
+    borderRightWidth: 2,
+    borderTopRightRadius: 6,
+    borderBottomRightRadius: 6,
+  },
   hourLabel: {
     fontSize: 11,
     fontWeight: '500',
@@ -446,6 +446,7 @@ const styles = StyleSheet.create({
     width: 14,
     height: 14,
     borderRadius: 3,
+    borderWidth: 1.5,
   },
   legendText: {
     fontSize: 13,

--- a/components/ChartDetailView.tsx
+++ b/components/ChartDetailView.tsx
@@ -103,18 +103,15 @@ export function ChartDetailView({
           <Text style={[styles.metricsTitle, { color: colors.text }]}>{metrics.label}</Text>
 
           {sections.map(({ data, accentColor: sectionAccentColor, label }) => (
-            <View key={label} style={{ marginTop: 12 }}>
+            <View key={label} style={styles.sectionMarginTop}>
               <Text style={[styles.sectionSubtitle, { color: colors.textSecondary }]}>{label}</Text>
 
               {data.current !== null && data.current !== undefined && (
                 <View
                   style={[
                     styles.currentValueContainer,
-                    {
-                      backgroundColor: colors.surface,
-                      borderLeftWidth: 3,
-                      borderLeftColor: sectionAccentColor,
-                    },
+                    styles.currentValueBorder,
+                    { backgroundColor: colors.surface, borderLeftColor: sectionAccentColor },
                   ]}
                 >
                   <Text style={[styles.currentLabel, { color: colors.text }]}>
@@ -164,11 +161,8 @@ export function ChartDetailView({
           <View
             style={[
               styles.currentValueContainer,
-              {
-                backgroundColor: colors.surface,
-                borderLeftWidth: 3,
-                borderLeftColor: accentColor ?? colors.primary,
-              },
+              styles.currentValueBorder,
+              { backgroundColor: colors.surface, borderLeftColor: accentColor ?? colors.primary },
             ]}
           >
             <Text style={[styles.currentLabel, { color: colors.text }]}>{t.metricCurrent}</Text>
@@ -206,7 +200,7 @@ export function ChartDetailView({
   };
 
   const renderContent = () => (
-    <View style={{ flex: 1 }}>
+    <View style={styles.flexOne}>
       {/* Chart always shown – use detailChildren override when available */}
       <View ref={chartCaptureRef} style={styles.chartContainer} collapsable={false}>
         {detailChildren ?? children}
@@ -262,11 +256,11 @@ export function ChartDetailView({
             ]}
           >
             <Text style={[styles.modalTitle, { color: colors.text }]}>{title}</Text>
-            {viewToggle && <View style={{ marginTop: 8 }}>{viewToggle}</View>}
+            {viewToggle && <View style={styles.viewToggleMarginTop}>{viewToggle}</View>}
           </View>
 
           {/* Content */}
-          <ScrollView style={{ flex: 1 }}>{renderContent()}</ScrollView>
+          <ScrollView style={styles.flexOne}>{renderContent()}</ScrollView>
 
           {/* Footer: Share + Close buttons */}
           <View
@@ -344,6 +338,18 @@ const styles = StyleSheet.create({
   footerButton: {
     flex: 1,
     minHeight: 48,
+  },
+  flexOne: {
+    flex: 1,
+  },
+  sectionMarginTop: {
+    marginTop: 12,
+  },
+  currentValueBorder: {
+    borderLeftWidth: 3,
+  },
+  viewToggleMarginTop: {
+    marginTop: 8,
   },
   metricsContainer: {
     margin: 16,

--- a/components/ChartSection.tsx
+++ b/components/ChartSection.tsx
@@ -15,6 +15,8 @@ import type { calculateMetrics } from '../utils/metrics';
 
 type Metrics = ReturnType<typeof calculateMetrics>;
 
+const ACTIVE_VIEW_TOGGLE_TEXT_COLOR = '#fff';
+
 type Props = {
   filteredEnergyData: EnergyData[];
   hourlyEnergyData: EnergyData[];
@@ -90,7 +92,7 @@ export function ChartSection({
   return (
     <>
       {/* KPI Row */}
-      <View style={{ flexDirection: 'row', marginHorizontal: 12, marginTop: 12, gap: 8 }}>
+      <View style={styles.kpiRow}>
         <KpiCard
           label={t.renewableNow}
           value={metrics?.today?.renewable.current}
@@ -136,15 +138,13 @@ export function ChartSection({
         }
         legend={
           showRegional ? (
-            <View style={{ gap: 8 }}>
-              <Text style={{ color: colors.text, fontSize: 13, fontWeight: '600' }}>
-                {t.legend}
-              </Text>
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-                <View
-                  style={{ width: 16, height: 3, backgroundColor: '#FF9800', borderRadius: 1.5 }}
-                />
-                <Text style={{ color: colors.text, fontSize: 12 }}>{t.regionalDataLabel}</Text>
+            <View style={styles.legendContainer}>
+              <Text style={[styles.legendTitle, { color: colors.text }]}>{t.legend}</Text>
+              <View style={styles.legendRow}>
+                <View style={styles.legendLineRegional} />
+                <Text style={[styles.legendLabel, { color: colors.text }]}>
+                  {t.regionalDataLabel}
+                </Text>
               </View>
             </View>
           ) : undefined
@@ -213,45 +213,39 @@ export function ChartSection({
             : undefined
         }
         viewToggle={
-          <View style={{ flexDirection: 'row', gap: 6 }}>
+          <View style={styles.viewToggleRow}>
             <TouchableOpacity
               onPress={() => handlePriceClockViewChange(false)}
-              style={{
-                paddingHorizontal: 10,
-                paddingVertical: 4,
-                borderRadius: 8,
-                backgroundColor: !priceClockView ? colors.primary : colors.gridLine,
-              }}
+              style={[
+                styles.viewToggleButton,
+                { backgroundColor: !priceClockView ? colors.primary : colors.gridLine },
+              ]}
               accessibilityLabel={t.viewBar}
               accessibilityRole="button"
             >
               <Text
-                style={{
-                  color: !priceClockView ? '#fff' : colors.text,
-                  fontSize: 12,
-                  fontWeight: '600',
-                }}
+                style={[
+                  styles.viewToggleLabel,
+                  { color: !priceClockView ? ACTIVE_VIEW_TOGGLE_TEXT_COLOR : colors.text },
+                ]}
               >
                 {t.viewBar}
               </Text>
             </TouchableOpacity>
             <TouchableOpacity
               onPress={() => handlePriceClockViewChange(true)}
-              style={{
-                paddingHorizontal: 10,
-                paddingVertical: 4,
-                borderRadius: 8,
-                backgroundColor: priceClockView ? colors.primary : colors.gridLine,
-              }}
+              style={[
+                styles.viewToggleButton,
+                { backgroundColor: priceClockView ? colors.primary : colors.gridLine },
+              ]}
               accessibilityLabel={t.viewClock}
               accessibilityRole="button"
             >
               <Text
-                style={{
-                  color: priceClockView ? '#fff' : colors.text,
-                  fontSize: 12,
-                  fontWeight: '600',
-                }}
+                style={[
+                  styles.viewToggleLabel,
+                  { color: priceClockView ? ACTIVE_VIEW_TOGGLE_TEXT_COLOR : colors.text },
+                ]}
               >
                 {t.viewClock}
               </Text>
@@ -259,21 +253,19 @@ export function ChartSection({
           </View>
         }
         legend={
-          <View style={{ gap: 8 }}>
-            <Text style={{ color: colors.text, fontSize: 13, fontWeight: '600' }}>{t.legend}</Text>
-            <View style={{ gap: 6 }}>
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-                <View
-                  style={{ width: 16, height: 16, backgroundColor: '#4CAF50', borderRadius: 2 }}
-                />
-                <Text style={{ color: colors.text, fontSize: 12 }}>{t.marketPriceLabel}</Text>
+          <View style={styles.legendContainer}>
+            <Text style={[styles.legendTitle, { color: colors.text }]}>{t.legend}</Text>
+            <View style={styles.legendGroup}>
+              <View style={styles.legendRow}>
+                <View style={styles.legendSquareGreen} />
+                <Text style={[styles.legendLabel, { color: colors.text }]}>
+                  {t.marketPriceLabel}
+                </Text>
               </View>
               {priceDisplayMode === 'withGridFees' && (
-                <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-                  <View
-                    style={{ width: 16, height: 16, backgroundColor: '#757575', borderRadius: 2 }}
-                  />
-                  <Text style={{ color: colors.text, fontSize: 12 }}>
+                <View style={styles.legendRow}>
+                  <View style={styles.legendSquareGray} />
+                  <Text style={[styles.legendLabel, { color: colors.text }]}>
                     {t.gridFeesLabel} ({gridFees} ¢/kWh)
                   </Text>
                 </View>
@@ -282,20 +274,18 @@ export function ChartSection({
           </View>
         }
         detailLegend={
-          <View style={{ gap: 8 }}>
-            <Text style={{ color: colors.text, fontSize: 13, fontWeight: '600' }}>{t.legend}</Text>
-            <View style={{ gap: 6 }}>
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-                <View
-                  style={{ width: 16, height: 16, backgroundColor: '#4CAF50', borderRadius: 2 }}
-                />
-                <Text style={{ color: colors.text, fontSize: 12 }}>{t.marketPriceLabel}</Text>
+          <View style={styles.legendContainer}>
+            <Text style={[styles.legendTitle, { color: colors.text }]}>{t.legend}</Text>
+            <View style={styles.legendGroup}>
+              <View style={styles.legendRow}>
+                <View style={styles.legendSquareGreen} />
+                <Text style={[styles.legendLabel, { color: colors.text }]}>
+                  {t.marketPriceLabel}
+                </Text>
               </View>
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
-                <View
-                  style={{ width: 16, height: 16, backgroundColor: '#757575', borderRadius: 2 }}
-                />
-                <Text style={{ color: colors.text, fontSize: 12 }}>
+              <View style={styles.legendRow}>
+                <View style={styles.legendSquareGray} />
+                <Text style={[styles.legendLabel, { color: colors.text }]}>
                   {t.gridFeesLabel} ({gridFees} ¢/kWh)
                 </Text>
               </View>
@@ -406,6 +396,18 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     marginBottom: 4,
   },
+  kpiRow: { flexDirection: 'row', marginHorizontal: 12, marginTop: 12, gap: 8 },
+  legendContainer: { gap: 8 },
+  legendTitle: { fontSize: 13, fontWeight: '600' },
+  legendGroup: { gap: 6 },
+  legendRow: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  legendLineRegional: { width: 16, height: 3, backgroundColor: '#FF9800', borderRadius: 1.5 },
+  legendSquareGreen: { width: 16, height: 16, backgroundColor: '#4CAF50', borderRadius: 2 },
+  legendSquareGray: { width: 16, height: 16, backgroundColor: '#757575', borderRadius: 2 },
+  legendLabel: { fontSize: 12 },
+  viewToggleRow: { flexDirection: 'row', gap: 6 },
+  viewToggleButton: { paddingHorizontal: 10, paddingVertical: 4, borderRadius: 8 },
+  viewToggleLabel: { fontSize: 12, fontWeight: '600' },
   infoText: {
     fontSize: 14,
     textAlign: 'center',

--- a/components/HistoricalDataView.tsx
+++ b/components/HistoricalDataView.tsx
@@ -28,6 +28,8 @@ import { RenewableBarChart } from './charts/RenewableBarChart';
 
 type TimeRange = '24h' | '48h' | '7d' | '30d';
 
+const ACTIVE_RANGE_TEXT_COLOR = '#fff';
+
 const DAY_MS = 24 * 60 * 60 * 1000;
 const HOUR_MS = 60 * 60 * 1000;
 
@@ -202,7 +204,10 @@ export function HistoricalDataView({
               accessibilityRole="button"
             >
               <Text
-                style={[styles.rangeButtonText, { color: timeRange === r ? '#fff' : colors.text }]}
+                style={[
+                  styles.rangeButtonText,
+                  { color: timeRange === r ? ACTIVE_RANGE_TEXT_COLOR : colors.text },
+                ]}
               >
                 {rangeLabel[r]}
               </Text>

--- a/components/MetricsView.tsx
+++ b/components/MetricsView.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { View, Text } from 'react-native';
+import React, { useMemo } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
 import type { Metrics } from '../utils/metrics';
 import { GRID_FEES_AND_TAXES } from '../utils/metrics';
 import type { ThemeColors } from '../utils/theme';
@@ -7,6 +7,67 @@ import type { ThemeColors } from '../utils/theme';
 interface MetricsViewProps {
   metrics: Metrics;
   colors: ThemeColors;
+}
+
+const BUBBLE_MIN_SIZE = 40;
+const BUBBLE_SCALE_FACTOR = 1.2;
+const BUBBLE_MIN_RADIUS = 20;
+const BUBBLE_RADIUS_FACTOR = 0.6;
+
+function createStyles(colors: ThemeColors, renewableAvg: number) {
+  const nonRenewablePercentage = 100 - renewableAvg;
+
+  return StyleSheet.create({
+    container: {
+      backgroundColor: colors.surface,
+      margin: 12,
+      padding: 16,
+      borderRadius: 12,
+      elevation: 2,
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 1 },
+      shadowOpacity: 0.1,
+      shadowRadius: 2,
+    },
+    title: { fontSize: 18, fontWeight: 'bold', marginBottom: 8, color: colors.text },
+    subtitle: { fontSize: 13, color: colors.textSecondary, marginBottom: 16 },
+    currentValueBox: {
+      marginBottom: 20,
+      padding: 12,
+      backgroundColor: colors.background,
+      borderRadius: 8,
+    },
+    sectionLabel: { color: colors.text, fontSize: 14, fontWeight: '600', marginBottom: 8 },
+    statsRow: { flexDirection: 'row', justifyContent: 'space-around' },
+    statColumn: { alignItems: 'center' },
+    statCaption: { color: colors.textSecondary, fontSize: 11 },
+    statValue: { color: colors.text, fontSize: 16, fontWeight: 'bold' },
+    section: { marginBottom: 20 },
+    bubbleSection: { marginTop: 16, alignItems: 'center' },
+    bubbleSectionLabel: { color: colors.textSecondary, fontSize: 12, marginBottom: 12 },
+    bubbleRow: { flexDirection: 'row', justifyContent: 'center', alignItems: 'center', gap: 20 },
+    bubbleColumn: { alignItems: 'center' },
+    renewableBubble: {
+      width: Math.max(BUBBLE_MIN_SIZE, renewableAvg * BUBBLE_SCALE_FACTOR),
+      height: Math.max(BUBBLE_MIN_SIZE, renewableAvg * BUBBLE_SCALE_FACTOR),
+      borderRadius: Math.max(BUBBLE_MIN_RADIUS, renewableAvg * BUBBLE_RADIUS_FACTOR),
+      backgroundColor: '#4CAF50',
+      opacity: 0.8,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    nonRenewableBubble: {
+      width: Math.max(BUBBLE_MIN_SIZE, nonRenewablePercentage * BUBBLE_SCALE_FACTOR),
+      height: Math.max(BUBBLE_MIN_SIZE, nonRenewablePercentage * BUBBLE_SCALE_FACTOR),
+      borderRadius: Math.max(BUBBLE_MIN_RADIUS, nonRenewablePercentage * BUBBLE_RADIUS_FACTOR),
+      backgroundColor: '#9E9E9E',
+      opacity: 0.8,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    bubbleValue: { color: '#fff', fontSize: 14, fontWeight: 'bold' },
+    bubbleCaption: { color: colors.textSecondary, fontSize: 10, marginTop: 4 },
+  });
 }
 
 export function MetricsView({ metrics, colors }: MetricsViewProps) {
@@ -29,62 +90,46 @@ export function MetricsView({ metrics, colors }: MetricsViewProps) {
     },
   };
 
+  const styles = useMemo(
+    () => createStyles(colors, displayMetrics.renewable.avg),
+    [colors, displayMetrics.renewable.avg]
+  );
+
+  const nonRenewablePercentage = 100 - displayMetrics.renewable.avg;
+
   return (
-    <View
-      style={{
-        backgroundColor: colors.surface,
-        margin: 12,
-        padding: 16,
-        borderRadius: 12,
-        elevation: 2,
-        shadowColor: '#000',
-        shadowOffset: { width: 0, height: 1 },
-        shadowOpacity: 0.1,
-        shadowRadius: 2,
-      }}
-    >
-      <Text style={{ fontSize: 18, fontWeight: 'bold', marginBottom: 8, color: colors.text }}>
-        Metriken
-      </Text>
-      <Text style={{ fontSize: 13, color: colors.textSecondary, marginBottom: 16 }}>
+    <View style={styles.container}>
+      <Text style={styles.title}>Metriken</Text>
+      <Text style={styles.subtitle}>
         {metrics.today ? `Heute (${displayMetrics.date})` : 'Gesamt-Zeitraum'}
       </Text>
 
       {/* Aktueller Wert (wenn verfügbar) */}
       {displayMetrics.marketPrice.current !== null && (
-        <View
-          style={{
-            marginBottom: 20,
-            padding: 12,
-            backgroundColor: colors.background,
-            borderRadius: 8,
-          }}
-        >
-          <Text style={{ color: colors.text, fontSize: 14, fontWeight: '600', marginBottom: 8 }}>
-            Aktuell
-          </Text>
-          <View style={{ flexDirection: 'row', justifyContent: 'space-around' }}>
-            <View style={{ alignItems: 'center' }}>
-              <Text style={{ color: colors.textSecondary, fontSize: 11 }}>Erneuerbare</Text>
-              <Text style={{ color: colors.text, fontSize: 16, fontWeight: 'bold' }}>
+        <View style={styles.currentValueBox}>
+          <Text style={styles.sectionLabel}>Aktuell</Text>
+          <View style={styles.statsRow}>
+            <View style={styles.statColumn}>
+              <Text style={styles.statCaption}>Erneuerbare</Text>
+              <Text style={styles.statValue}>
                 {displayMetrics.renewable.current !== null
                   ? displayMetrics.renewable.current.toFixed(1)
                   : '—'}
                 %
               </Text>
             </View>
-            <View style={{ alignItems: 'center' }}>
-              <Text style={{ color: colors.textSecondary, fontSize: 11 }}>Börsenpreis</Text>
-              <Text style={{ color: colors.text, fontSize: 16, fontWeight: 'bold' }}>
+            <View style={styles.statColumn}>
+              <Text style={styles.statCaption}>Börsenpreis</Text>
+              <Text style={styles.statValue}>
                 {displayMetrics.marketPrice.current !== null
                   ? displayMetrics.marketPrice.current.toFixed(2)
                   : '—'}{' '}
                 ¢
               </Text>
             </View>
-            <View style={{ alignItems: 'center' }}>
-              <Text style={{ color: colors.textSecondary, fontSize: 11 }}>Endkunde</Text>
-              <Text style={{ color: colors.text, fontSize: 16, fontWeight: 'bold' }}>
+            <View style={styles.statColumn}>
+              <Text style={styles.statCaption}>Endkunde</Text>
+              <Text style={styles.statValue}>
                 {displayMetrics.endCustomerPrice.current !== null
                   ? displayMetrics.endCustomerPrice.current.toFixed(2)
                   : '—'}{' '}
@@ -96,171 +141,80 @@ export function MetricsView({ metrics, colors }: MetricsViewProps) {
       )}
 
       {/* Erneuerbare Energien */}
-      <View style={{ marginBottom: 20 }}>
-        <Text style={{ color: colors.text, fontSize: 14, fontWeight: '600', marginBottom: 8 }}>
-          Anteil Erneuerbarer Energien (%)
-        </Text>
-        <View style={{ flexDirection: 'row', justifyContent: 'space-around' }}>
-          <View style={{ alignItems: 'center' }}>
-            <Text style={{ color: colors.textSecondary, fontSize: 11 }}>Durchschnitt</Text>
-            <Text style={{ color: colors.text, fontSize: 16, fontWeight: 'bold' }}>
-              {displayMetrics.renewable.avg.toFixed(1)}%
-            </Text>
+      <View style={styles.section}>
+        <Text style={styles.sectionLabel}>Anteil Erneuerbarer Energien (%)</Text>
+        <View style={styles.statsRow}>
+          <View style={styles.statColumn}>
+            <Text style={styles.statCaption}>Durchschnitt</Text>
+            <Text style={styles.statValue}>{displayMetrics.renewable.avg.toFixed(1)}%</Text>
           </View>
-          <View style={{ alignItems: 'center' }}>
-            <Text style={{ color: colors.textSecondary, fontSize: 11 }}>Minimum</Text>
-            <Text style={{ color: colors.text, fontSize: 16, fontWeight: 'bold' }}>
-              {displayMetrics.renewable.min.toFixed(1)}%
-            </Text>
+          <View style={styles.statColumn}>
+            <Text style={styles.statCaption}>Minimum</Text>
+            <Text style={styles.statValue}>{displayMetrics.renewable.min.toFixed(1)}%</Text>
           </View>
-          <View style={{ alignItems: 'center' }}>
-            <Text style={{ color: colors.textSecondary, fontSize: 11 }}>Maximum</Text>
-            <Text style={{ color: colors.text, fontSize: 16, fontWeight: 'bold' }}>
-              {displayMetrics.renewable.max.toFixed(1)}%
-            </Text>
+          <View style={styles.statColumn}>
+            <Text style={styles.statCaption}>Maximum</Text>
+            <Text style={styles.statValue}>{displayMetrics.renewable.max.toFixed(1)}%</Text>
           </View>
         </View>
 
         {/* Energy Mix Visualization - Bubble Chart */}
-        <View style={{ marginTop: 16, alignItems: 'center' }}>
-          <Text style={{ color: colors.textSecondary, fontSize: 12, marginBottom: 12 }}>
-            Energiemix (Durchschnitt)
-          </Text>
-          <View
-            style={{
-              flexDirection: 'row',
-              justifyContent: 'center',
-              alignItems: 'center',
-              gap: 20,
-            }}
-          >
-            {(() => {
-              const BUBBLE_MIN_SIZE = 40;
-              const BUBBLE_SCALE_FACTOR = 1.2;
-              const BUBBLE_MIN_RADIUS = 20;
-              const BUBBLE_RADIUS_FACTOR = 0.6;
-              const nonRenewablePercentage = 100 - displayMetrics.renewable.avg;
+        <View style={styles.bubbleSection}>
+          <Text style={styles.bubbleSectionLabel}>Energiemix (Durchschnitt)</Text>
+          <View style={styles.bubbleRow}>
+            {/* Renewable bubble */}
+            <View style={styles.bubbleColumn}>
+              <View style={styles.renewableBubble}>
+                <Text style={styles.bubbleValue}>{displayMetrics.renewable.avg.toFixed(0)}%</Text>
+              </View>
+              <Text style={styles.bubbleCaption}>Erneuerbar</Text>
+            </View>
 
-              return (
-                <>
-                  {/* Renewable bubble */}
-                  <View style={{ alignItems: 'center' }}>
-                    <View
-                      style={{
-                        width: Math.max(
-                          BUBBLE_MIN_SIZE,
-                          displayMetrics.renewable.avg * BUBBLE_SCALE_FACTOR
-                        ),
-                        height: Math.max(
-                          BUBBLE_MIN_SIZE,
-                          displayMetrics.renewable.avg * BUBBLE_SCALE_FACTOR
-                        ),
-                        borderRadius: Math.max(
-                          BUBBLE_MIN_RADIUS,
-                          displayMetrics.renewable.avg * BUBBLE_RADIUS_FACTOR
-                        ),
-                        backgroundColor: '#4CAF50',
-                        opacity: 0.8,
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                      }}
-                    >
-                      <Text style={{ color: '#fff', fontSize: 14, fontWeight: 'bold' }}>
-                        {displayMetrics.renewable.avg.toFixed(0)}%
-                      </Text>
-                    </View>
-                    <Text style={{ color: colors.textSecondary, fontSize: 10, marginTop: 4 }}>
-                      Erneuerbar
-                    </Text>
-                  </View>
-
-                  {/* Non-renewable bubble */}
-                  <View style={{ alignItems: 'center' }}>
-                    <View
-                      style={{
-                        width: Math.max(
-                          BUBBLE_MIN_SIZE,
-                          nonRenewablePercentage * BUBBLE_SCALE_FACTOR
-                        ),
-                        height: Math.max(
-                          BUBBLE_MIN_SIZE,
-                          nonRenewablePercentage * BUBBLE_SCALE_FACTOR
-                        ),
-                        borderRadius: Math.max(
-                          BUBBLE_MIN_RADIUS,
-                          nonRenewablePercentage * BUBBLE_RADIUS_FACTOR
-                        ),
-                        backgroundColor: '#9E9E9E',
-                        opacity: 0.8,
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                      }}
-                    >
-                      <Text style={{ color: '#fff', fontSize: 14, fontWeight: 'bold' }}>
-                        {nonRenewablePercentage.toFixed(0)}%
-                      </Text>
-                    </View>
-                    <Text style={{ color: colors.textSecondary, fontSize: 10, marginTop: 4 }}>
-                      Konventionell
-                    </Text>
-                  </View>
-                </>
-              );
-            })()}
+            {/* Non-renewable bubble */}
+            <View style={styles.bubbleColumn}>
+              <View style={styles.nonRenewableBubble}>
+                <Text style={styles.bubbleValue}>{nonRenewablePercentage.toFixed(0)}%</Text>
+              </View>
+              <Text style={styles.bubbleCaption}>Konventionell</Text>
+            </View>
           </View>
         </View>
       </View>
 
       {/* Börsenstrompreis */}
-      <View style={{ marginBottom: 20 }}>
-        <Text style={{ color: colors.text, fontSize: 14, fontWeight: '600', marginBottom: 8 }}>
-          Börsenstrompreis (Cent/kWh)
-        </Text>
-        <View style={{ flexDirection: 'row', justifyContent: 'space-around' }}>
-          <View style={{ alignItems: 'center' }}>
-            <Text style={{ color: colors.textSecondary, fontSize: 11 }}>Durchschnitt</Text>
-            <Text style={{ color: colors.text, fontSize: 16, fontWeight: 'bold' }}>
-              {displayMetrics.marketPrice.avg.toFixed(2)} ¢
-            </Text>
+      <View style={styles.section}>
+        <Text style={styles.sectionLabel}>Börsenstrompreis (Cent/kWh)</Text>
+        <View style={styles.statsRow}>
+          <View style={styles.statColumn}>
+            <Text style={styles.statCaption}>Durchschnitt</Text>
+            <Text style={styles.statValue}>{displayMetrics.marketPrice.avg.toFixed(2)} ¢</Text>
           </View>
-          <View style={{ alignItems: 'center' }}>
-            <Text style={{ color: colors.textSecondary, fontSize: 11 }}>Minimum</Text>
-            <Text style={{ color: colors.text, fontSize: 16, fontWeight: 'bold' }}>
-              {displayMetrics.marketPrice.min.toFixed(2)} ¢
-            </Text>
+          <View style={styles.statColumn}>
+            <Text style={styles.statCaption}>Minimum</Text>
+            <Text style={styles.statValue}>{displayMetrics.marketPrice.min.toFixed(2)} ¢</Text>
           </View>
-          <View style={{ alignItems: 'center' }}>
-            <Text style={{ color: colors.textSecondary, fontSize: 11 }}>Maximum</Text>
-            <Text style={{ color: colors.text, fontSize: 16, fontWeight: 'bold' }}>
-              {displayMetrics.marketPrice.max.toFixed(2)} ¢
-            </Text>
+          <View style={styles.statColumn}>
+            <Text style={styles.statCaption}>Maximum</Text>
+            <Text style={styles.statValue}>{displayMetrics.marketPrice.max.toFixed(2)} ¢</Text>
           </View>
         </View>
       </View>
 
       {/* Endkundenstrompreis (inkl. Netzentgelte) */}
       <View>
-        <Text style={{ color: colors.text, fontSize: 14, fontWeight: '600', marginBottom: 8 }}>
-          Endkundenstrompreis (Cent/kWh)
-        </Text>
-        <View style={{ flexDirection: 'row', justifyContent: 'space-around' }}>
-          <View style={{ alignItems: 'center' }}>
-            <Text style={{ color: colors.textSecondary, fontSize: 11 }}>Durchschnitt</Text>
-            <Text style={{ color: colors.text, fontSize: 16, fontWeight: 'bold' }}>
-              {displayMetrics.endCustomerPrice.avg.toFixed(2)} ¢
-            </Text>
+        <Text style={styles.sectionLabel}>Endkundenstrompreis (Cent/kWh)</Text>
+        <View style={styles.statsRow}>
+          <View style={styles.statColumn}>
+            <Text style={styles.statCaption}>Durchschnitt</Text>
+            <Text style={styles.statValue}>{displayMetrics.endCustomerPrice.avg.toFixed(2)} ¢</Text>
           </View>
-          <View style={{ alignItems: 'center' }}>
-            <Text style={{ color: colors.textSecondary, fontSize: 11 }}>Minimum</Text>
-            <Text style={{ color: colors.text, fontSize: 16, fontWeight: 'bold' }}>
-              {displayMetrics.endCustomerPrice.min.toFixed(2)} ¢
-            </Text>
+          <View style={styles.statColumn}>
+            <Text style={styles.statCaption}>Minimum</Text>
+            <Text style={styles.statValue}>{displayMetrics.endCustomerPrice.min.toFixed(2)} ¢</Text>
           </View>
-          <View style={{ alignItems: 'center' }}>
-            <Text style={{ color: colors.textSecondary, fontSize: 11 }}>Maximum</Text>
-            <Text style={{ color: colors.text, fontSize: 16, fontWeight: 'bold' }}>
-              {displayMetrics.endCustomerPrice.max.toFixed(2)} ¢
-            </Text>
+          <View style={styles.statColumn}>
+            <Text style={styles.statCaption}>Maximum</Text>
+            <Text style={styles.statValue}>{displayMetrics.endCustomerPrice.max.toFixed(2)} ¢</Text>
           </View>
         </View>
       </View>

--- a/components/charts/ClockChart.tsx
+++ b/components/charts/ClockChart.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useCallback } from 'react';
-import { View, Text, Platform } from 'react-native';
+import { View, Text, Platform, StyleSheet } from 'react-native';
 import Svg, { Path, Circle, Line, G, Text as SvgText } from 'react-native-svg';
 import type { ThemeColors } from '../../utils/theme';
 import { getPriceColor } from '../../utils/chartHelpers';
@@ -148,50 +148,54 @@ function ClockChartComponent({
   return (
     <ChartCard backgroundColor={backgroundColor} margin={margin} cardPadding={cardPadding}>
       {/* Center info */}
-      <View style={{ alignItems: 'center', marginBottom: 8 }}>
+      <View style={styles.centerInfo}>
         {selectedSegment && selectedSegment.totalPrice !== null ? (
           <>
-            <Text style={{ color: textColor, fontSize: isPhone ? 13 : 15, fontWeight: '700' }}>
+            <Text
+              style={[
+                isPhone ? styles.rangeLabelPhone : styles.rangeLabelDefault,
+                { color: textColor },
+              ]}
+            >
               {selectedHour}:00 – {((selectedHour ?? 0) + 1) % 24}:00
             </Text>
             <Text
-              style={{
-                color: selectedSegment.color,
-                fontSize: isPhone ? 20 : 24,
-                fontWeight: '800',
-              }}
+              style={[
+                isPhone ? styles.priceValuePhone : styles.priceValueDefault,
+                { color: selectedSegment.color },
+              ]}
             >
               {selectedSegment.totalPrice.toFixed(2)} ¢
             </Text>
-            <Text style={{ color: textColor, fontSize: 11, opacity: 0.6 }}>
-              {labels.pricePerKwh}
-            </Text>
+            <Text style={[styles.priceUnit, { color: textColor }]}>{labels.pricePerKwh}</Text>
           </>
         ) : currentSegment.totalPrice !== null ? (
           <>
-            <Text style={{ color: textColor, fontSize: isPhone ? 11 : 13, opacity: 0.7 }}>
+            <Text
+              style={[
+                isPhone ? styles.nowLabelPhone : styles.nowLabelDefault,
+                { color: textColor },
+              ]}
+            >
               {labels.now}
             </Text>
             <Text
-              style={{
-                color: currentSegment.color,
-                fontSize: isPhone ? 20 : 24,
-                fontWeight: '800',
-              }}
+              style={[
+                isPhone ? styles.priceValuePhone : styles.priceValueDefault,
+                { color: currentSegment.color },
+              ]}
             >
               {currentSegment.totalPrice.toFixed(2)} ¢
             </Text>
-            <Text style={{ color: textColor, fontSize: 11, opacity: 0.6 }}>
-              {labels.pricePerKwh}
-            </Text>
+            <Text style={[styles.priceUnit, { color: textColor }]}>{labels.pricePerKwh}</Text>
           </>
         ) : (
-          <Text style={{ color: textColor, fontSize: 13, opacity: 0.5 }}>{labels.noData}</Text>
+          <Text style={[styles.noDataLabel, { color: textColor }]}>{labels.noData}</Text>
         )}
       </View>
 
       {/* Clock SVG */}
-      <View style={{ alignItems: 'center' }}>
+      <View style={styles.svgWrapper}>
         <Svg width={svgSize} height={svgSize}>
           {/* Background circle */}
           <Circle cx={cx} cy={cy} r={outerR + 4} fill={colors.gridLine} opacity={0.1} />
@@ -276,3 +280,16 @@ function ClockChartComponent({
 }
 
 export const ClockChart = React.memo(ClockChartComponent);
+
+const styles = StyleSheet.create({
+  centerInfo: { alignItems: 'center', marginBottom: 8 },
+  rangeLabelPhone: { fontSize: 13, fontWeight: '700' },
+  rangeLabelDefault: { fontSize: 15, fontWeight: '700' },
+  priceValuePhone: { fontSize: 20, fontWeight: '800' },
+  priceValueDefault: { fontSize: 24, fontWeight: '800' },
+  priceUnit: { fontSize: 11, opacity: 0.6 },
+  nowLabelPhone: { fontSize: 11, opacity: 0.7 },
+  nowLabelDefault: { fontSize: 13, opacity: 0.7 },
+  noDataLabel: { fontSize: 13, opacity: 0.5 },
+  svgWrapper: { alignItems: 'center' },
+});

--- a/components/charts/CorrelationScatterChart.tsx
+++ b/components/charts/CorrelationScatterChart.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { View, Text, Platform, ScrollView } from 'react-native';
+import { View, Text, Platform, ScrollView, StyleSheet } from 'react-native';
 import Svg, { Circle, Line } from 'react-native-svg';
 import type { ThemeColors } from '../../utils/theme';
 import { getYAxisLabelStyle } from '../../utils/chartHelpers';
@@ -269,7 +269,7 @@ function CorrelationScatterChartComponent({
               backgroundColor={backgroundColor}
               colors={colors}
             >
-              <Text style={{ color: colors.text, fontSize: 14, fontWeight: 'bold' }}>
+              <Text style={[styles.tooltipValue, { color: colors.text }]}>
                 {new Date(item.timestamp).toLocaleString('de-DE', {
                   day: '2-digit',
                   month: '2-digit',
@@ -280,35 +280,19 @@ function CorrelationScatterChartComponent({
             </ChartTooltip>
           );
         })()}
-      <View
-        style={{
-          flexDirection: 'row',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          marginBottom: 0,
-        }}
-      >
-        <View style={{ flex: 1, marginRight: 8 }}>
+      <View style={styles.headerRow}>
+        <View style={styles.titleColumn}>
           <Text
-            style={{
-              fontSize: isPhone ? 16 : 18,
-              fontWeight: 'bold',
-              marginBottom: 0,
-              color: textColor,
-            }}
+            style={[isPhone ? styles.titlePhone : styles.titleDefault, { color: textColor }]}
             numberOfLines={2}
             ellipsizeMode="tail"
           >
             {title}
           </Text>
-          {subtitle && (
-            <Text style={{ fontSize: 12, color: textColor, opacity: 0.7, marginBottom: 2 }}>
-              {subtitle}
-            </Text>
-          )}
+          {subtitle && <Text style={[styles.subtitle, { color: textColor }]}>{subtitle}</Text>}
           {interactionHint && (
             <Text
-              style={{ fontSize: 12, fontStyle: 'italic', opacity: 0.5, color: textColor }}
+              style={[styles.hint, { color: textColor }]}
               accessibilityRole="text"
               accessibilityLabel={interactionHint}
             >
@@ -318,39 +302,26 @@ function CorrelationScatterChartComponent({
         </View>
         {/* Legend - hidden on small devices in portrait mode */}
         {!(isPhone && !isLandscape) && (
-          <View
-            style={{
-              flexDirection: 'row',
-              gap: 12,
-              paddingRight: 10,
-              paddingTop: 0,
-            }}
-          >
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-              <View
-                style={{ width: 12, height: 12, borderRadius: 6, backgroundColor: '#2196F3' }}
-              />
-              <Text style={{ fontSize: 12, color: textColor, opacity: 0.7 }}>{labels.night}</Text>
+          <View style={styles.legendRow}>
+            <View style={styles.legendItem}>
+              <View style={styles.legendDotNight} />
+              <Text style={[styles.legendLabel, { color: textColor }]}>{labels.night}</Text>
             </View>
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-              <View
-                style={{ width: 12, height: 12, borderRadius: 6, backgroundColor: '#FF9800' }}
-              />
-              <Text style={{ fontSize: 12, color: textColor, opacity: 0.7 }}>
+            <View style={styles.legendItem}>
+              <View style={styles.legendDotMorningEvening} />
+              <Text style={[styles.legendLabel, { color: textColor }]}>
                 {labels.morningEvening}
               </Text>
             </View>
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-              <View
-                style={{ width: 12, height: 12, borderRadius: 6, backgroundColor: '#FFEB3B' }}
-              />
-              <Text style={{ fontSize: 12, color: textColor, opacity: 0.7 }}>{labels.day}</Text>
+            <View style={styles.legendItem}>
+              <View style={styles.legendDotDay} />
+              <Text style={[styles.legendLabel, { color: textColor }]}>{labels.day}</Text>
             </View>
           </View>
         )}
       </View>
       <View
-        style={{ height: chartHeight, width: viewportWidth, position: 'relative' }}
+        style={[styles.relative, { height: chartHeight, width: viewportWidth }]}
         {...gestureContainerProps}
       >
         <ScrollView
@@ -410,15 +381,15 @@ function CorrelationScatterChartComponent({
               return (
                 <View
                   key={`touch-${point.index}`}
-                  style={{
-                    position: 'absolute',
-                    left: point.x - touchSize / 2,
-                    top: point.y - touchSize / 2,
-                    width: touchSize,
-                    height: touchSize,
-                    zIndex: 10,
-                    cursor: Platform.OS === 'web' ? 'pointer' : undefined,
-                  }}
+                  style={[
+                    Platform.OS === 'web' ? styles.touchAreaWeb : styles.touchArea,
+                    {
+                      left: point.x - touchSize / 2,
+                      top: point.y - touchSize / 2,
+                      width: touchSize,
+                      height: touchSize,
+                    },
+                  ]}
                   onStartShouldSetResponder={() => true}
                   onResponderGrant={() =>
                     setSelectedIndex(prev => (point.index === prev ? null : point.index))
@@ -438,14 +409,10 @@ function CorrelationScatterChartComponent({
               return (
                 <Text
                   key={`xlabel-${i}`}
-                  style={{
-                    position: 'absolute',
-                    left: x - 15,
-                    top: chartHeight - (isPhone ? 25 : 30),
-                    fontSize: 12,
-                    color: textColor,
-                    opacity: 0.6,
-                  }}
+                  style={[
+                    styles.xAxisLabel,
+                    { left: x - 15, top: chartHeight - (isPhone ? 25 : 30), color: textColor },
+                  ]}
                 >
                   {value.toFixed(0)}%
                 </Text>
@@ -454,15 +421,10 @@ function CorrelationScatterChartComponent({
 
             {/* Axis Labels */}
             <Text
-              style={{
-                position: 'absolute',
-                left: chartWidth / 2 - 60,
-                bottom: isPhone ? 0 : 3,
-                fontSize: 12,
-                color: textColor,
-                opacity: 0.6,
-                fontWeight: '600',
-              }}
+              style={[
+                isPhone ? styles.xAxisTitlePhone : styles.xAxisTitleDefault,
+                { left: chartWidth / 2 - 60, color: textColor },
+              ]}
             >
               {labels.xAxisRenewables}
             </Text>
@@ -476,16 +438,10 @@ function CorrelationScatterChartComponent({
           return (
             <Text
               key={`ylabel-${i}`}
-              style={{
-                position: 'absolute',
-                left: 10,
-                top: y - 8,
-                fontSize: 12,
-                color: textColor,
-                opacity: 0.6,
-                textAlign: 'right',
-                width: isPhone ? 25 : 30,
-              }}
+              style={[
+                isPhone ? styles.yAxisLabelPhone : styles.yAxisLabelDefault,
+                { top: y - 8, color: textColor },
+              ]}
             >
               {value.toFixed(0)}
             </Text>
@@ -501,25 +457,8 @@ function CorrelationScatterChartComponent({
         )}
       </View>
       {insightText && (
-        <View
-          style={{
-            marginTop: 10,
-            paddingHorizontal: 12,
-            paddingVertical: 8,
-            borderRadius: 10,
-            borderWidth: 1.5,
-            borderColor: colors.gridLine,
-          }}
-        >
-          <Text
-            style={{
-              fontSize: 12,
-              color: textColor,
-              opacity: 0.7,
-            }}
-          >
-            {insightText}
-          </Text>
+        <View style={[styles.insightBox, { borderColor: colors.gridLine }]}>
+          <Text style={[styles.insightText, { color: textColor }]}>{insightText}</Text>
         </View>
       )}
       {interactionHint && (
@@ -527,13 +466,7 @@ function CorrelationScatterChartComponent({
           accessible={true}
           accessibilityRole="text"
           accessibilityLabel={interactionHint}
-          style={{
-            fontSize: 12,
-            color: textColor,
-            opacity: 0.5,
-            fontStyle: 'italic',
-            marginTop: 8,
-          }}
+          style={[styles.interactionHintText, { color: textColor }]}
         >
           {interactionHint}
         </Text>
@@ -545,3 +478,72 @@ function CorrelationScatterChartComponent({
 // Performance: Wrap with React.memo to prevent unnecessary re-renders
 // Only re-renders if props actually change
 export const CorrelationScatterChart = React.memo(CorrelationScatterChartComponent);
+
+const styles = StyleSheet.create({
+  tooltipValue: { fontSize: 14, fontWeight: 'bold' },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 0,
+  },
+  titleColumn: { flex: 1, marginRight: 8 },
+  titlePhone: { fontSize: 16, fontWeight: 'bold', marginBottom: 0 },
+  titleDefault: { fontSize: 18, fontWeight: 'bold', marginBottom: 0 },
+  subtitle: { fontSize: 12, opacity: 0.7, marginBottom: 2 },
+  hint: { fontSize: 12, fontStyle: 'italic', opacity: 0.5 },
+  legendRow: { flexDirection: 'row', gap: 12, paddingRight: 10, paddingTop: 0 },
+  legendItem: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  legendDotNight: { width: 12, height: 12, borderRadius: 6, backgroundColor: '#2196F3' },
+  legendDotMorningEvening: { width: 12, height: 12, borderRadius: 6, backgroundColor: '#FF9800' },
+  legendDotDay: { width: 12, height: 12, borderRadius: 6, backgroundColor: '#FFEB3B' },
+  legendLabel: { fontSize: 12, opacity: 0.7 },
+  relative: { position: 'relative' },
+  touchArea: { position: 'absolute', zIndex: 10 },
+  touchAreaWeb: { position: 'absolute', zIndex: 10, cursor: 'pointer' },
+  xAxisLabel: { position: 'absolute', fontSize: 12, opacity: 0.6 },
+  xAxisTitlePhone: {
+    position: 'absolute',
+    fontSize: 12,
+    opacity: 0.6,
+    fontWeight: '600',
+    bottom: 0,
+  },
+  xAxisTitleDefault: {
+    position: 'absolute',
+    fontSize: 12,
+    opacity: 0.6,
+    fontWeight: '600',
+    bottom: 3,
+  },
+  yAxisLabelPhone: {
+    position: 'absolute',
+    left: 10,
+    fontSize: 12,
+    opacity: 0.6,
+    textAlign: 'right',
+    width: 25,
+  },
+  yAxisLabelDefault: {
+    position: 'absolute',
+    left: 10,
+    fontSize: 12,
+    opacity: 0.6,
+    textAlign: 'right',
+    width: 30,
+  },
+  insightBox: {
+    marginTop: 10,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 10,
+    borderWidth: 1.5,
+  },
+  insightText: { fontSize: 12, opacity: 0.7 },
+  interactionHintText: {
+    fontSize: 12,
+    opacity: 0.5,
+    fontStyle: 'italic',
+    marginTop: 8,
+  },
+});

--- a/components/charts/PriceBarChart.tsx
+++ b/components/charts/PriceBarChart.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useCallback } from 'react';
-import { View, Text, Platform, ScrollView } from 'react-native';
+import { View, Text, Platform, ScrollView, StyleSheet } from 'react-native';
 import Svg, { Rect, Line } from 'react-native-svg';
 import type { ThemeColors } from '../../utils/theme';
 import { getYAxisLabelStyle, getPriceColor } from '../../utils/chartHelpers';
@@ -240,15 +240,9 @@ function PriceBarChartComponent({
               minWidth={180}
             >
               {/* Market Price */}
-              <View
-                style={{
-                  flexDirection: 'row',
-                  justifyContent: 'space-between',
-                  marginBottom: isMarketOnly ? 0 : 4,
-                }}
-              >
-                <Text style={{ color: '#4CAF50', fontSize: 11 }}>{labels.tooltipMarketPrice}</Text>
-                <Text style={{ color: colors.text, fontSize: 11, fontWeight: '600' }}>
+              <View style={isMarketOnly ? styles.tooltipRow : styles.tooltipRowMarginBottom4}>
+                <Text style={styles.tooltipMarketLabel}>{labels.tooltipMarketPrice}</Text>
+                <Text style={[styles.tooltipValueSmallBold, { color: colors.text }]}>
                   {marketPriceCent.toFixed(2)} ¢
                 </Text>
               </View>
@@ -257,37 +251,24 @@ function PriceBarChartComponent({
               {!isMarketOnly && (
                 <>
                   {/* Grid Fees */}
-                  <View
-                    style={{
-                      flexDirection: 'row',
-                      justifyContent: 'space-between',
-                      marginBottom: 6,
-                    }}
-                  >
-                    <Text style={{ color: colors.textSecondary, fontSize: 11 }}>
+                  <View style={styles.tooltipRowMarginBottom6}>
+                    <Text style={[styles.tooltipLabelSmall, { color: colors.textSecondary }]}>
                       {labels.tooltipGridFees}
                     </Text>
-                    <Text style={{ color: colors.text, fontSize: 11, fontWeight: '600' }}>
+                    <Text style={[styles.tooltipValueSmallBold, { color: colors.text }]}>
                       {gridFees.toFixed(2)} ¢
                     </Text>
                   </View>
 
                   {/* Divider */}
-                  <View
-                    style={{
-                      height: 1,
-                      backgroundColor: colors.gridLine,
-                      marginVertical: 6,
-                      opacity: 0.5,
-                    }}
-                  />
+                  <View style={[styles.tooltipDivider, { backgroundColor: colors.gridLine }]} />
 
                   {/* Total Price */}
-                  <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
-                    <Text style={{ color: colors.text, fontSize: 12, fontWeight: '600' }}>
+                  <View style={styles.tooltipRow}>
+                    <Text style={[styles.tooltipTotalLabel, { color: colors.text }]}>
                       {labels.tooltipEndCustomer}
                     </Text>
-                    <Text style={{ color: colors.primary, fontSize: 12, fontWeight: '700' }}>
+                    <Text style={[styles.tooltipTotalValue, { color: colors.primary }]}>
                       {totalPrice.toFixed(2)} ¢
                     </Text>
                   </View>
@@ -296,43 +277,19 @@ function PriceBarChartComponent({
             </ChartTooltip>
           );
         })()}
-      <View
-        style={{
-          flexDirection: 'row',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          marginBottom: 0,
-        }}
-      >
-        <View style={{ flex: 1, marginRight: 8 }}>
+      <View style={styles.headerRow}>
+        <View style={styles.titleColumn}>
           <Text
-            style={{
-              fontSize: isPhone ? 17 : 20,
-              fontWeight: '800',
-              marginBottom: 0,
-              color: textColor,
-            }}
+            style={[isPhone ? styles.titlePhone : styles.titleDefault, { color: textColor }]}
             numberOfLines={2}
             ellipsizeMode="tail"
           >
             {title}
           </Text>
-          {subtitle && (
-            <Text
-              style={{
-                fontSize: 11,
-                color: textColor,
-                opacity: 0.7,
-                marginBottom: 2,
-                fontWeight: '600',
-              }}
-            >
-              {subtitle}
-            </Text>
-          )}
+          {subtitle && <Text style={[styles.subtitle, { color: textColor }]}>{subtitle}</Text>}
           {interactionHint && (
             <Text
-              style={{ fontSize: 11, fontStyle: 'italic', opacity: 0.5, color: textColor }}
+              style={[styles.hint, { color: textColor }]}
               accessibilityRole="text"
               accessibilityLabel={interactionHint}
             >
@@ -342,39 +299,28 @@ function PriceBarChartComponent({
         </View>
         {/* Legend - hidden when showLegend is false or on small devices in portrait mode */}
         {showLegend && !(isPhone && !isLandscape) && (
-          <View
-            style={{
-              flexDirection: 'row',
-              gap: 12,
-              paddingRight: 10,
-              paddingTop: 0,
-            }}
-          >
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-              <View style={{ width: 10, height: 10, backgroundColor: '#4CAF50' }} />
-              <Text style={{ fontSize: 11, color: textColor, opacity: 0.7 }}>
-                {labels.marketPrice}
-              </Text>
+          <View style={styles.legendRow}>
+            <View style={styles.legendItem}>
+              <View style={styles.legendDotMarket} />
+              <Text style={[styles.legendLabel, { color: textColor }]}>{labels.marketPrice}</Text>
             </View>
             {!isMarketOnly && (
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-                <View style={{ width: 10, height: 10, backgroundColor: '#757575' }} />
-                <Text style={{ fontSize: 11, color: textColor, opacity: 0.7 }}>
+              <View style={styles.legendItem}>
+                <View style={styles.legendDotGrid} />
+                <Text style={[styles.legendLabel, { color: textColor }]}>
                   {labels.gridFeesAndTaxes} ({gridFees} ¢/kWh)
                 </Text>
               </View>
             )}
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-              <View style={{ width: 10, height: 10, backgroundColor: '#4CAF50', opacity: 0.4 }} />
-              <Text style={{ fontSize: 11, color: textColor, opacity: 0.7 }}>
-                {labels.interpolated}
-              </Text>
+            <View style={styles.legendItem}>
+              <View style={styles.legendDotInterpolated} />
+              <Text style={[styles.legendLabel, { color: textColor }]}>{labels.interpolated}</Text>
             </View>
           </View>
         )}
       </View>
       <View
-        style={{ height: chartHeight, width: viewportWidth, position: 'relative' }}
+        style={[styles.relative, { height: chartHeight, width: viewportWidth }]}
         {...gestureContainerProps}
       >
         <ScrollView
@@ -383,7 +329,7 @@ function PriceBarChartComponent({
           style={{ width: viewportWidth, height: chartHeight }}
           contentContainerStyle={{ width: chartWidth, height: chartHeight }}
         >
-          <View style={{ height: chartHeight, width: chartWidth, position: 'relative' }}>
+          <View style={[styles.relative, { height: chartHeight, width: chartWidth }]}>
             <ChartGrid
               chartWidth={chartWidth}
               chartHeight={chartHeight}
@@ -498,17 +444,17 @@ function PriceBarChartComponent({
               return (
                 <View
                   key={`touch-${bar.index}`}
-                  style={{
-                    position: 'absolute',
-                    left: bar.x - bar.barWidth / 2,
-                    top: isMarketOnly ? bar.marketY : bar.gridY,
-                    width: bar.barWidth,
-                    height: isMarketOnly
-                      ? bar.marketBarHeight
-                      : bar.marketBarHeight + bar.gridBarHeight,
-                    zIndex: 10,
-                    cursor: Platform.OS === 'web' ? 'pointer' : undefined,
-                  }}
+                  style={[
+                    Platform.OS === 'web' ? styles.touchAreaWeb : styles.touchArea,
+                    {
+                      left: bar.x - bar.barWidth / 2,
+                      top: isMarketOnly ? bar.marketY : bar.gridY,
+                      width: bar.barWidth,
+                      height: isMarketOnly
+                        ? bar.marketBarHeight
+                        : bar.marketBarHeight + bar.gridBarHeight,
+                    },
+                  ]}
                   onStartShouldSetResponder={() => true}
                   onResponderGrant={() => handleBarInteraction(bar.index)}
                   {...(Platform.OS === 'web' && {
@@ -521,19 +467,18 @@ function PriceBarChartComponent({
 
             {/* Durchschnittslinie Label */}
             <Text
-              style={{
-                position: 'absolute',
-                right: rightPadding + 4,
-                top:
-                  chartHeight -
-                  bottomPadding -
-                  ((avgMarketPrice - min) / range) * (chartHeight - padding - bottomPadding) -
-                  11,
-                fontSize: 11,
-                color: textColor,
-                fontWeight: '700',
-                opacity: 0.7,
-              }}
+              style={[
+                styles.averageLabel,
+                {
+                  right: rightPadding + 4,
+                  top:
+                    chartHeight -
+                    bottomPadding -
+                    ((avgMarketPrice - min) / range) * (chartHeight - padding - bottomPadding) -
+                    11,
+                  color: textColor,
+                },
+              ]}
             >
               {labels.average} {avgMarketPrice.toFixed(2)} ¢
             </Text>
@@ -562,15 +507,10 @@ function PriceBarChartComponent({
                 xAxisLabels.push(
                   <Text
                     key={`xlabel-${timestamp}`}
-                    style={{
-                      position: 'absolute',
-                      left: x - 10,
-                      top: chartHeight - bottomPadding + 5,
-                      fontSize: 11,
-                      color: textColor,
-                      opacity: 0.6,
-                      fontWeight: '600',
-                    }}
+                    style={[
+                      styles.xAxisLabel,
+                      { left: x - 10, top: chartHeight - bottomPadding + 5, color: textColor },
+                    ]}
                   >
                     {hour}h
                   </Text>
@@ -583,19 +523,7 @@ function PriceBarChartComponent({
             })()}
 
             {/* End-of-chart label */}
-            <Text
-              style={{
-                position: 'absolute',
-                right: 2,
-                bottom: bottomPadding + 4,
-                fontSize: 10,
-                color: textColor,
-                opacity: 0.35,
-                fontWeight: '700',
-                textTransform: 'uppercase',
-                letterSpacing: 0.6,
-              }}
-            >
+            <Text style={[styles.endOfChartLabel, { bottom: bottomPadding + 4, color: textColor }]}>
               EPEX
             </Text>
           </View>
@@ -608,16 +536,10 @@ function PriceBarChartComponent({
           return (
             <Text
               key={`ylabel-${i}`}
-              style={{
-                position: 'absolute',
-                left: 10,
-                top: y - 8,
-                fontSize: 11,
-                color: textColor,
-                opacity: 0.6,
-                textAlign: 'right',
-                width: isPhone ? 25 : 30,
-              }}
+              style={[
+                isPhone ? styles.yAxisLabelPhone : styles.yAxisLabelDefault,
+                { top: y - 8, color: textColor },
+              ]}
             >
               {value.toFixed(0)}
             </Text>
@@ -636,13 +558,7 @@ function PriceBarChartComponent({
           accessible={true}
           accessibilityRole="text"
           accessibilityLabel={interactionHint}
-          style={{
-            fontSize: 11,
-            color: textColor,
-            opacity: 0.5,
-            fontStyle: 'italic',
-            marginTop: 6,
-          }}
+          style={[styles.interactionHintText, { color: textColor }]}
         >
           {interactionHint}
         </Text>
@@ -654,3 +570,76 @@ function PriceBarChartComponent({
 // Performance: Wrap with React.memo to prevent unnecessary re-renders
 // Only re-renders if props actually change
 export const PriceBarChart = React.memo(PriceBarChartComponent);
+
+const styles = StyleSheet.create({
+  tooltipRow: { flexDirection: 'row', justifyContent: 'space-between' },
+  tooltipRowMarginBottom4: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 4,
+  },
+  tooltipRowMarginBottom6: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 6,
+  },
+  tooltipMarketLabel: { color: '#4CAF50', fontSize: 11 },
+  tooltipLabelSmall: { fontSize: 11 },
+  tooltipValueSmallBold: { fontSize: 11, fontWeight: '600' },
+  tooltipDivider: { height: 1, marginVertical: 6, opacity: 0.5 },
+  tooltipTotalLabel: { fontSize: 12, fontWeight: '600' },
+  tooltipTotalValue: { fontSize: 12, fontWeight: '700' },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 0,
+  },
+  titleColumn: { flex: 1, marginRight: 8 },
+  titlePhone: { fontSize: 17, fontWeight: '800', marginBottom: 0 },
+  titleDefault: { fontSize: 20, fontWeight: '800', marginBottom: 0 },
+  subtitle: { fontSize: 11, opacity: 0.7, marginBottom: 2, fontWeight: '600' },
+  hint: { fontSize: 11, fontStyle: 'italic', opacity: 0.5 },
+  legendRow: { flexDirection: 'row', gap: 12, paddingRight: 10, paddingTop: 0 },
+  legendItem: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  legendDotMarket: { width: 10, height: 10, backgroundColor: '#4CAF50' },
+  legendDotGrid: { width: 10, height: 10, backgroundColor: '#757575' },
+  legendDotInterpolated: { width: 10, height: 10, backgroundColor: '#4CAF50', opacity: 0.4 },
+  legendLabel: { fontSize: 11, opacity: 0.7 },
+  relative: { position: 'relative' },
+  touchArea: { position: 'absolute', zIndex: 10 },
+  touchAreaWeb: { position: 'absolute', zIndex: 10, cursor: 'pointer' },
+  averageLabel: { position: 'absolute', fontSize: 11, fontWeight: '700', opacity: 0.7 },
+  xAxisLabel: { position: 'absolute', fontSize: 11, opacity: 0.6, fontWeight: '600' },
+  endOfChartLabel: {
+    position: 'absolute',
+    right: 2,
+    fontSize: 10,
+    opacity: 0.35,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+  },
+  yAxisLabelPhone: {
+    position: 'absolute',
+    left: 10,
+    fontSize: 11,
+    opacity: 0.6,
+    textAlign: 'right',
+    width: 25,
+  },
+  yAxisLabelDefault: {
+    position: 'absolute',
+    left: 10,
+    fontSize: 11,
+    opacity: 0.6,
+    textAlign: 'right',
+    width: 30,
+  },
+  interactionHintText: {
+    fontSize: 11,
+    opacity: 0.5,
+    fontStyle: 'italic',
+    marginTop: 6,
+  },
+});

--- a/components/charts/RenewableBarChart.tsx
+++ b/components/charts/RenewableBarChart.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useCallback } from 'react';
-import { View, Text, Platform, ScrollView } from 'react-native';
+import { View, Text, Platform, ScrollView, StyleSheet } from 'react-native';
 import Svg, { Rect, Line, Polyline } from 'react-native-svg';
 import type { ThemeColors } from '../../utils/theme';
 import { getYAxisLabelStyle } from '../../utils/chartHelpers';
@@ -268,41 +268,25 @@ function RenewableBarChartComponent({
               backgroundColor={backgroundColor}
               colors={colors}
             >
-              <Text style={{ color: colors.text, fontSize: 14, fontWeight: 'bold' }}>
+              <Text style={[styles.tooltipValue, { color: colors.text }]}>
                 {renewablePercent.toFixed(1)}%
               </Text>
             </ChartTooltip>
           );
         })()}
-      <View
-        style={{
-          flexDirection: 'row',
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
-          marginBottom: 0,
-        }}
-      >
-        <View style={{ flex: 1, marginRight: 8 }}>
+      <View style={styles.headerRow}>
+        <View style={styles.titleColumn}>
           <Text
-            style={{
-              fontSize: isPhone ? 16 : 18,
-              fontWeight: 'bold',
-              marginBottom: 0,
-              color: textColor,
-            }}
+            style={[isPhone ? styles.titlePhone : styles.titleDefault, { color: textColor }]}
             numberOfLines={2}
             ellipsizeMode="tail"
           >
             {title}
           </Text>
-          {subtitle && (
-            <Text style={{ fontSize: 12, color: textColor, opacity: 0.7, marginBottom: 2 }}>
-              {subtitle}
-            </Text>
-          )}
+          {subtitle && <Text style={[styles.subtitle, { color: textColor }]}>{subtitle}</Text>}
           {interactionHint && (
             <Text
-              style={{ fontSize: 12, fontStyle: 'italic', opacity: 0.5, color: textColor }}
+              style={[styles.hint, { color: textColor }]}
               accessibilityRole="text"
               accessibilityLabel={interactionHint}
             >
@@ -312,45 +296,22 @@ function RenewableBarChartComponent({
         </View>
         {/* Legend - hidden when showLegend is false or on small devices in portrait mode */}
         {showLegend && !(isPhone && !isLandscape) && (
-          <View
-            style={{
-              flexDirection: 'row',
-              gap: 12,
-              paddingRight: 10,
-              paddingTop: 0,
-            }}
-          >
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-              <View
-                style={{
-                  width: 12,
-                  height: 2,
-                  backgroundColor: textColor,
-                  opacity: 0.5,
-                }}
-              />
-              <Text style={{ fontSize: 12, color: textColor, opacity: 0.7 }}>{labels.average}</Text>
+          <View style={styles.legendRow}>
+            <View style={styles.legendItem}>
+              <View style={[styles.legendLine, { backgroundColor: textColor }]} />
+              <Text style={[styles.legendLabel, { color: textColor }]}>{labels.average}</Text>
             </View>
             {showRegionalLine && (
-              <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
-                <View
-                  style={{
-                    width: 12,
-                    height: 2,
-                    backgroundColor: '#FF9800',
-                    opacity: 0.8,
-                  }}
-                />
-                <Text style={{ fontSize: 12, color: textColor, opacity: 0.7 }}>
-                  {labels.regional}
-                </Text>
+              <View style={styles.legendItem}>
+                <View style={styles.legendLineRegional} />
+                <Text style={[styles.legendLabel, { color: textColor }]}>{labels.regional}</Text>
               </View>
             )}
           </View>
         )}
       </View>
       <View
-        style={{ height: chartHeight, width: viewportWidth, position: 'relative' }}
+        style={[styles.relative, { height: chartHeight, width: viewportWidth }]}
         {...gestureContainerProps}
       >
         <ScrollView
@@ -359,7 +320,7 @@ function RenewableBarChartComponent({
           style={{ width: viewportWidth, height: chartHeight }}
           contentContainerStyle={{ width: chartWidth, height: chartHeight }}
         >
-          <View style={{ height: chartHeight, width: chartWidth, position: 'relative' }}>
+          <View style={[styles.relative, { height: chartHeight, width: chartWidth }]}>
             <ChartGrid
               chartWidth={chartWidth}
               chartHeight={chartHeight}
@@ -526,20 +487,18 @@ function RenewableBarChartComponent({
                       />
                       {labels.regional && (
                         <Text
-                          style={{
-                            position: 'absolute',
-                            right: rightPadding + 4,
-                            top:
-                              chartHeight -
-                              bottomPadding -
-                              ((regionalAvg - min) / range) *
-                                (chartHeight - padding - bottomPadding) +
-                              12,
-                            fontSize: 12,
-                            color: '#FF9800',
-                            fontWeight: '600',
-                            opacity: 0.9,
-                          }}
+                          style={[
+                            styles.regionalLabel,
+                            {
+                              right: rightPadding + 4,
+                              top:
+                                chartHeight -
+                                bottomPadding -
+                                ((regionalAvg - min) / range) *
+                                  (chartHeight - padding - bottomPadding) +
+                                12,
+                            },
+                          ]}
                         >
                           {labels.regional} {regionalAvg.toFixed(1)}%
                         </Text>
@@ -571,15 +530,15 @@ function RenewableBarChartComponent({
               return (
                 <View
                   key={`touch-${bar.index}`}
-                  style={{
-                    position: 'absolute',
-                    left: bar.x - bar.barWidth / 2,
-                    top: bar.y,
-                    width: bar.barWidth,
-                    height: bar.barHeight,
-                    zIndex: 10,
-                    cursor: Platform.OS === 'web' ? 'pointer' : undefined,
-                  }}
+                  style={[
+                    Platform.OS === 'web' ? styles.touchAreaWeb : styles.touchArea,
+                    {
+                      left: bar.x - bar.barWidth / 2,
+                      top: bar.y,
+                      width: bar.barWidth,
+                      height: bar.barHeight,
+                    },
+                  ]}
                   onStartShouldSetResponder={() => true}
                   onResponderGrant={() => handleBarInteraction(bar.index)}
                   {...(Platform.OS === 'web' && {
@@ -592,19 +551,18 @@ function RenewableBarChartComponent({
 
             {/* Durchschnittslinie Label */}
             <Text
-              style={{
-                position: 'absolute',
-                right: rightPadding + 4,
-                top:
-                  chartHeight -
-                  bottomPadding -
-                  ((avgValue - min) / range) * (chartHeight - padding - bottomPadding) -
-                  12,
-                fontSize: 12,
-                color: textColor,
-                fontWeight: '600',
-                opacity: 0.7,
-              }}
+              style={[
+                styles.averageLabel,
+                {
+                  right: rightPadding + 4,
+                  top:
+                    chartHeight -
+                    bottomPadding -
+                    ((avgValue - min) / range) * (chartHeight - padding - bottomPadding) -
+                    12,
+                  color: textColor,
+                },
+              ]}
             >
               {labels.average} {avgValue.toFixed(1)}%
             </Text>
@@ -633,14 +591,10 @@ function RenewableBarChartComponent({
                 xAxisLabels.push(
                   <Text
                     key={`xlabel-${timestamp}`}
-                    style={{
-                      position: 'absolute',
-                      left: x - 10,
-                      top: chartHeight - bottomPadding + 5,
-                      fontSize: 12,
-                      color: textColor,
-                      opacity: 0.6,
-                    }}
+                    style={[
+                      styles.xAxisLabel,
+                      { left: x - 10, top: chartHeight - bottomPadding + 5, color: textColor },
+                    ]}
                   >
                     {hour}h
                   </Text>
@@ -661,16 +615,10 @@ function RenewableBarChartComponent({
           return (
             <Text
               key={`ylabel-${i}`}
-              style={{
-                position: 'absolute',
-                left: 10,
-                top: y - 8,
-                fontSize: 12,
-                color: textColor,
-                opacity: 0.6,
-                textAlign: 'right',
-                width: isPhone ? 25 : 30,
-              }}
+              style={[
+                isPhone ? styles.yAxisLabelPhone : styles.yAxisLabelDefault,
+                { top: y - 8, color: textColor },
+              ]}
             >
               {value.toFixed(0)}
             </Text>
@@ -689,13 +637,7 @@ function RenewableBarChartComponent({
           accessible={true}
           accessibilityRole="text"
           accessibilityLabel={interactionHint}
-          style={{
-            fontSize: 12,
-            color: textColor,
-            opacity: 0.5,
-            fontStyle: 'italic',
-            marginTop: 8,
-          }}
+          style={[styles.interactionHintText, { color: textColor }]}
         >
           {interactionHint}
         </Text>
@@ -707,3 +649,57 @@ function RenewableBarChartComponent({
 // Performance: Wrap with React.memo to prevent unnecessary re-renders
 // Only re-renders if props actually change
 export const RenewableBarChart = React.memo(RenewableBarChartComponent);
+
+const styles = StyleSheet.create({
+  tooltipValue: { fontSize: 14, fontWeight: 'bold' },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: 0,
+  },
+  titleColumn: { flex: 1, marginRight: 8 },
+  titlePhone: { fontSize: 16, fontWeight: 'bold', marginBottom: 0 },
+  titleDefault: { fontSize: 18, fontWeight: 'bold', marginBottom: 0 },
+  subtitle: { fontSize: 12, opacity: 0.7, marginBottom: 2 },
+  hint: { fontSize: 12, fontStyle: 'italic', opacity: 0.5 },
+  legendRow: { flexDirection: 'row', gap: 12, paddingRight: 10, paddingTop: 0 },
+  legendItem: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  legendLine: { width: 12, height: 2, opacity: 0.5 },
+  legendLineRegional: { width: 12, height: 2, backgroundColor: '#FF9800', opacity: 0.8 },
+  legendLabel: { fontSize: 12, opacity: 0.7 },
+  relative: { position: 'relative' },
+  regionalLabel: {
+    position: 'absolute',
+    fontSize: 12,
+    color: '#FF9800',
+    fontWeight: '600',
+    opacity: 0.9,
+  },
+  touchArea: { position: 'absolute', zIndex: 10 },
+  touchAreaWeb: { position: 'absolute', zIndex: 10, cursor: 'pointer' },
+  averageLabel: { position: 'absolute', fontSize: 12, fontWeight: '600', opacity: 0.7 },
+  xAxisLabel: { position: 'absolute', fontSize: 12, opacity: 0.6 },
+  yAxisLabelPhone: {
+    position: 'absolute',
+    left: 10,
+    fontSize: 12,
+    opacity: 0.6,
+    textAlign: 'right',
+    width: 25,
+  },
+  yAxisLabelDefault: {
+    position: 'absolute',
+    left: 10,
+    fontSize: 12,
+    opacity: 0.6,
+    textAlign: 'right',
+    width: 30,
+  },
+  interactionHintText: {
+    fontSize: 12,
+    opacity: 0.5,
+    fontStyle: 'italic',
+    marginTop: 8,
+  },
+});

--- a/components/charts/__tests__/ClockChart.test.tsx
+++ b/components/charts/__tests__/ClockChart.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * ClockChart Tests
+ * Rendering, hour-bucket aggregation, and segment-selection for the 24h clock chart.
+ */
+
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { ClockChart } from '../ClockChart';
+import { SettingsProvider } from '../../../context/SettingsContext';
+import { getThemeColors } from '../../../utils/theme';
+
+const colors = getThemeColors('light', 'light');
+
+const labels = {
+  now: 'Jetzt',
+  average: 'Ø',
+  pricePerKwh: 'ct/kWh',
+  noData: 'Keine Daten',
+};
+
+function buildFullDayData(overrides?: (hour: number) => Partial<{ marketPrice: number | null }>) {
+  const now = new Date();
+  return Array.from({ length: 24 }, (_, hour) => {
+    const d = new Date(now);
+    d.setHours(hour, 0, 0, 0);
+    return {
+      timestamp: d.getTime(),
+      marketPrice: 100 + hour * 5,
+      renewableShare: 50,
+      isMarketPriceInterpolated: false,
+      ...(overrides ? overrides(hour) : {}),
+    };
+  });
+}
+
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <SettingsProvider>{children}</SettingsProvider>
+);
+
+function renderChart(props: Partial<React.ComponentProps<typeof ClockChart>> = {}) {
+  return render(
+    <TestWrapper>
+      <ClockChart
+        data={buildFullDayData()}
+        backgroundColor={colors.surface}
+        textColor={colors.text}
+        colors={colors}
+        gridFees={20}
+        labels={labels}
+        {...props}
+      />
+    </TestWrapper>
+  );
+}
+
+describe('ClockChart', () => {
+  it('renders without crashing for a full day of data', async () => {
+    const { UNSAFE_root } = renderChart();
+    await waitFor(() => {
+      expect(UNSAFE_root).toBeTruthy();
+    });
+  });
+
+  it('shows the "now" label and a price for the current hour by default', async () => {
+    const { getByText } = renderChart();
+    await waitFor(() => {
+      expect(getByText('Jetzt')).toBeTruthy();
+    });
+    expect(getByText('ct/kWh')).toBeTruthy();
+  });
+
+  it('shows the no-data label when every hour is empty', async () => {
+    const data = buildFullDayData(() => ({ marketPrice: null }));
+    const { getByText, queryByText } = renderChart({ data });
+    await waitFor(() => {
+      expect(getByText('Keine Daten')).toBeTruthy();
+    });
+    expect(queryByText('Jetzt')).toBeNull();
+  });
+
+  it('does not throw for an empty dataset (falls back to empty hour buckets)', async () => {
+    const { getByText } = renderChart({ data: [] });
+    await waitFor(() => {
+      expect(getByText('Keine Daten')).toBeTruthy();
+    });
+  });
+
+  it('does not throw when only some hours have data', async () => {
+    const data = buildFullDayData(hour => (hour % 2 === 0 ? { marketPrice: null } : {}));
+    const { UNSAFE_root } = renderChart({ data });
+    await waitFor(() => {
+      expect(UNSAFE_root).toBeTruthy();
+    });
+  });
+
+  it('selects an hour segment on hover (web) and shows its price range', async () => {
+    const { UNSAFE_root, getByText } = renderChart();
+
+    const segments = UNSAFE_root.findAll(
+      (node: { type: unknown; props: Record<string, unknown> }) =>
+        node.type === 'View' && typeof node.props.onMouseEnter === 'function'
+    );
+    expect(segments.length).toBe(24);
+
+    fireEvent(segments[5], 'mouseEnter');
+
+    await waitFor(() => {
+      expect(getByText('5:00 – 6:00')).toBeTruthy();
+    });
+  });
+
+  it('deselects the hour segment on mouse leave', async () => {
+    const { UNSAFE_root, getByText, queryByText } = renderChart();
+    const segments = UNSAFE_root.findAll(
+      (node: { type: unknown; props: Record<string, unknown> }) =>
+        node.type === 'View' && typeof node.props.onMouseEnter === 'function'
+    );
+
+    fireEvent(segments[5], 'mouseEnter');
+    await waitFor(() => {
+      expect(getByText('5:00 – 6:00')).toBeTruthy();
+    });
+
+    fireEvent(segments[5], 'mouseLeave');
+    await waitFor(() => {
+      expect(queryByText('5:00 – 6:00')).toBeNull();
+    });
+  });
+
+  it('marks a fully-interpolated hour without throwing', async () => {
+    const data = buildFullDayData(hour => (hour === 3 ? {} : {})).map((d, i) =>
+      i === 3 ? { ...d, isMarketPriceInterpolated: true } : d
+    );
+    const { UNSAFE_root } = renderChart({ data });
+    await waitFor(() => {
+      expect(UNSAFE_root).toBeTruthy();
+    });
+  });
+});

--- a/components/charts/shared/ChartCard.tsx
+++ b/components/charts/shared/ChartCard.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect } from 'react';
-import type { ViewStyle } from 'react-native';
+import React, { useEffect, useMemo } from 'react';
+import { StyleSheet, type ViewStyle } from 'react-native';
 import { borderRadius } from '../../../utils/designSystem';
 import Animated, {
   cancelAnimation,
@@ -49,10 +49,10 @@ function ChartCardComponent({
     transform: [{ translateY: translateY.value }],
   }));
 
-  return (
-    <Animated.View
-      style={[
-        {
+  const cardStyle = useMemo(
+    () =>
+      StyleSheet.create({
+        card: {
           backgroundColor,
           margin,
           padding: cardPadding,
@@ -66,14 +66,12 @@ function ChartCardComponent({
           ...(accentColor?.startsWith('#')
             ? { borderWidth: 1, borderColor: accentColor + '33' }
             : {}),
-          ...style,
         },
-        animatedStyle,
-      ]}
-    >
-      {children}
-    </Animated.View>
+      }).card,
+    [backgroundColor, margin, cardPadding, accentColor]
   );
+
+  return <Animated.View style={[cardStyle, style, animatedStyle]}>{children}</Animated.View>;
 }
 
 export const ChartCard = React.memo(ChartCardComponent);

--- a/components/charts/shared/ChartGrid.tsx
+++ b/components/charts/shared/ChartGrid.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
+import { StyleSheet } from 'react-native';
 import Svg, { Line } from 'react-native-svg';
+
+const styles = StyleSheet.create({
+  svg: { position: 'absolute' },
+});
 
 interface ChartGridProps {
   chartWidth: number;
@@ -27,7 +32,7 @@ function ChartGridComponent({
   verticalLines = 0,
 }: ChartGridProps) {
   return (
-    <Svg width={chartWidth} height={chartHeight} style={{ position: 'absolute' }}>
+    <Svg width={chartWidth} height={chartHeight} style={styles.svg}>
       {Array.from({ length: horizontalLines }, (_, i) => {
         const y = padding + (i / (horizontalLines - 1)) * (chartHeight - padding - bottomPadding);
         return (

--- a/components/charts/shared/ChartTooltip.tsx
+++ b/components/charts/shared/ChartTooltip.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect } from 'react';
-import { Platform } from 'react-native';
+import React, { useEffect, useMemo } from 'react';
+import { Platform, StyleSheet } from 'react-native';
 import Animated, {
   cancelAnimation,
   useAnimatedStyle,
@@ -49,10 +49,10 @@ function ChartTooltipComponent({
     transform: [{ scale: scale.value }],
   }));
 
-  return (
-    <Animated.View
-      style={[
-        {
+  const tooltipStyle = useMemo(
+    () =>
+      StyleSheet.create({
+        tooltip: {
           paddingVertical: 6,
           paddingHorizontal: 12,
           backgroundColor: tooltipBgColor,
@@ -73,12 +73,11 @@ function ChartTooltipComponent({
             backdropFilter: 'blur(10px)',
           }),
         },
-        animatedStyle,
-      ]}
-    >
-      {children}
-    </Animated.View>
+      }).tooltip,
+    [tooltipBgColor, colors.gridLine, cardPadding, tooltipLeft, minWidth]
   );
+
+  return <Animated.View style={[tooltipStyle, animatedStyle]}>{children}</Animated.View>;
 }
 
 export const ChartTooltip = React.memo(ChartTooltipComponent);

--- a/components/charts/shared/NowMarker.tsx
+++ b/components/charts/shared/NowMarker.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Text } from 'react-native';
+import React, { useMemo } from 'react';
+import { StyleSheet, Text } from 'react-native';
 import { Line } from 'react-native-svg';
 import { scaleToX } from './chartScale';
 
@@ -78,18 +78,19 @@ export function NowMarkerLabel({
     leftPadding,
     rightPadding,
   });
-  return (
-    <Text
-      style={{
-        position: 'absolute',
-        left: x - 15,
-        top: chartHeight - bottomPadding + 20,
-        fontSize: 12,
-        color: 'red',
-        fontWeight: 'bold',
-      }}
-    >
-      {label}
-    </Text>
+  const style = useMemo(
+    () =>
+      StyleSheet.create({
+        label: {
+          position: 'absolute',
+          left: x - 15,
+          top: chartHeight - bottomPadding + 20,
+          fontSize: 12,
+          color: 'red',
+          fontWeight: 'bold',
+        },
+      }).label,
+    [x, chartHeight, bottomPadding]
   );
+  return <Text style={style}>{label}</Text>;
 }

--- a/components/customize/HistoryCacheSection.tsx
+++ b/components/customize/HistoryCacheSection.tsx
@@ -6,6 +6,8 @@ import { useSettingsContext } from '../../context/SettingsContext';
 import { HISTORY_CACHE_LIMIT_OPTIONS_MB } from '../../hooks/useSettings';
 import { historicalDataStore, type HistoryStorageInfo } from '../../services/historicalDataStore';
 
+const ACTIVE_TOGGLE_TEXT_COLOR = '#fff';
+
 /**
  * Cache-Einstellung für historische Daten (Issue #307).
  * Nutzer wählt die Speicher-Obergrenze (MB), sieht den belegten Speicher
@@ -61,11 +63,10 @@ export function HistoryCacheSection() {
             onPress={() => setHistoryCacheLimitMb(mb)}
           >
             <Text
-              style={{
-                color: historyCacheLimitMb === mb ? '#fff' : colors.text,
-                fontSize: 12,
-                fontWeight: '600',
-              }}
+              style={[
+                styles.toggleButtonLabel,
+                { color: historyCacheLimitMb === mb ? ACTIVE_TOGGLE_TEXT_COLOR : colors.text },
+              ]}
             >
               {mb} MB
             </Text>
@@ -126,6 +127,10 @@ const styles = StyleSheet.create({
     fontSize: 12,
   },
   clearButton: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  toggleButtonLabel: {
     fontSize: 12,
     fontWeight: '600',
   },

--- a/components/customize/PriceDisplayModeSection.tsx
+++ b/components/customize/PriceDisplayModeSection.tsx
@@ -4,6 +4,8 @@ import { useLanguageContext } from '../../context/LanguageContext';
 import { getThemeColors } from '../../utils/theme';
 import { useSettingsContext } from '../../context/SettingsContext';
 
+const ACTIVE_TOGGLE_TEXT_COLOR = '#fff';
+
 /**
  * Price display mode section in Customize modal.
  * Switches between market price only and end-customer price (market + grid fees) display.
@@ -30,11 +32,10 @@ export function PriceDisplayModeSection() {
             onPress={() => setPriceDisplayMode(mode)}
           >
             <Text
-              style={{
-                color: priceDisplayMode === mode ? '#fff' : colors.text,
-                fontSize: 12,
-                fontWeight: '600',
-              }}
+              style={[
+                styles.toggleButtonLabel,
+                { color: priceDisplayMode === mode ? ACTIVE_TOGGLE_TEXT_COLOR : colors.text },
+              ]}
             >
               {mode === 'marketOnly' ? t.priceDisplayMarketOnly : t.priceDisplayWithFees}
             </Text>
@@ -65,5 +66,9 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     borderRadius: 8,
     alignItems: 'center',
+  },
+  toggleButtonLabel: {
+    fontSize: 12,
+    fontWeight: '600',
   },
 });

--- a/components/settings/LanguageSection.tsx
+++ b/components/settings/LanguageSection.tsx
@@ -4,6 +4,8 @@ import { useLanguageContext } from '../../context/LanguageContext';
 import { getThemeColors } from '../../utils/theme';
 import { useSettingsContext } from '../../context/SettingsContext';
 
+const ACTIVE_LANGUAGE_TEXT_COLOR = '#fff';
+
 /**
  * Language selection section for Settings and Customize menus
  * Allows switching between English and German
@@ -27,11 +29,10 @@ export function LanguageSection() {
           onPress={() => setLanguage('en')}
         >
           <Text
-            style={{
-              color: language === 'en' ? '#fff' : colors.text,
-              fontSize: 12,
-              fontWeight: '600',
-            }}
+            style={[
+              styles.languageButtonLabel,
+              { color: language === 'en' ? ACTIVE_LANGUAGE_TEXT_COLOR : colors.text },
+            ]}
           >
             {t.english}
           </Text>
@@ -45,11 +46,10 @@ export function LanguageSection() {
           onPress={() => setLanguage('de')}
         >
           <Text
-            style={{
-              color: language === 'de' ? '#fff' : colors.text,
-              fontSize: 12,
-              fontWeight: '600',
-            }}
+            style={[
+              styles.languageButtonLabel,
+              { color: language === 'de' ? ACTIVE_LANGUAGE_TEXT_COLOR : colors.text },
+            ]}
           >
             {t.german}
           </Text>
@@ -87,5 +87,9 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.1,
     shadowRadius: 4,
     elevation: 2,
+  },
+  languageButtonLabel: {
+    fontSize: 12,
+    fontWeight: '600',
   },
 });

--- a/components/settings/SettingsMenu.tsx
+++ b/components/settings/SettingsMenu.tsx
@@ -21,6 +21,8 @@ import { getThemeColors } from '../../utils/theme';
 import { useSettingsContext } from '../../context/SettingsContext';
 import { AppearanceSection } from './AppearanceSection';
 
+const CUSTOMIZE_BUTTON_TEXT_COLOR = '#fff';
+
 interface SettingsMenuProps {
   visible: boolean;
   onClose: () => void;
@@ -107,7 +109,9 @@ export function SettingsMenu({
               onClose();
             }}
           >
-            <Text style={[styles.customizeButtonText, { color: '#fff' }]}>{t.customize}</Text>
+            <Text style={[styles.customizeButtonText, { color: CUSTOMIZE_BUTTON_TEXT_COLOR }]}>
+              {t.customize}
+            </Text>
           </TouchableOpacity>
 
           {/* History (#1, #3) */}

--- a/components/ui/ChartSkeleton.tsx
+++ b/components/ui/ChartSkeleton.tsx
@@ -58,7 +58,7 @@ function ChartSkeletonCard({ title = true }: ChartSkeletonCardProps) {
       {/* X-axis labels */}
       <View style={styles.xAxis}>
         {Array.from({ length: 4 }).map((_, i) => (
-          <SkeletonText key={i} width={30} style={{ height: 10 }} />
+          <SkeletonText key={i} width={30} style={styles.skeletonSmall} />
         ))}
       </View>
     </View>

--- a/components/ui/KpiCard.tsx
+++ b/components/ui/KpiCard.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { View, Text } from 'react-native';
+import React, { useMemo } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
 
 type Props = {
   label: string;
@@ -12,6 +12,36 @@ type Props = {
   surfaceColor: string;
   labelColor: string;
 };
+
+function createStyles(bg: string, border: string, labelColor: string, accentColor: string) {
+  return StyleSheet.create({
+    card: {
+      flex: 1,
+      backgroundColor: bg,
+      borderRadius: 20,
+      borderWidth: 1,
+      borderColor: border,
+      padding: 14,
+    },
+    label: {
+      fontSize: 10,
+      fontWeight: '600',
+      color: labelColor,
+      textTransform: 'uppercase',
+      letterSpacing: 0.8,
+      marginBottom: 6,
+    },
+    value: {
+      fontFamily: 'monospace',
+      fontSize: 28,
+      fontWeight: '700',
+      color: accentColor,
+      lineHeight: 32,
+      marginBottom: 4,
+    },
+    avg: { fontSize: 11, color: labelColor },
+  });
+}
 
 export function KpiCard({
   label,
@@ -29,43 +59,17 @@ export function KpiCard({
   const bg = isDark ? 'rgba(255,255,255,0.04)' : surfaceColor;
   const border = accentColor.startsWith('#') ? accentColor + '33' : 'transparent';
 
+  const styles = useMemo(
+    () => createStyles(bg, border, labelColor, accentColor),
+    [bg, border, labelColor, accentColor]
+  );
+
   return (
-    <View
-      style={{
-        flex: 1,
-        backgroundColor: bg,
-        borderRadius: 20,
-        borderWidth: 1,
-        borderColor: border,
-        padding: 14,
-      }}
-    >
-      <Text
-        style={{
-          fontSize: 10,
-          fontWeight: '600',
-          color: labelColor,
-          textTransform: 'uppercase',
-          letterSpacing: 0.8,
-          marginBottom: 6,
-        }}
-      >
-        {label}
-      </Text>
-      <Text
-        style={{
-          fontFamily: 'monospace',
-          fontSize: 28,
-          fontWeight: '700',
-          color: accentColor,
-          lineHeight: 32,
-          marginBottom: 4,
-        }}
-      >
-        {displayValue}
-      </Text>
+    <View style={styles.card}>
+      <Text style={styles.label}>{label}</Text>
+      <Text style={styles.value}>{displayValue}</Text>
       {displayAvg && (
-        <Text style={{ fontSize: 11, color: labelColor }}>
+        <Text style={styles.avg}>
           {avgLabel} {displayAvg}
         </Text>
       )}

--- a/components/ui/SkeletonLoader.tsx
+++ b/components/ui/SkeletonLoader.tsx
@@ -49,13 +49,8 @@ function SkeletonBase({ width = '100%', height, style }: SkeletonProps) {
     <View
       onLayout={handleLayout}
       style={[
-        {
-          width,
-          height,
-          backgroundColor: colors.border,
-          borderRadius: borderRadius.md,
-          overflow: 'hidden',
-        },
+        styles.base,
+        { width, height, backgroundColor: colors.border, borderRadius: borderRadius.md },
         style,
       ]}
     >
@@ -65,7 +60,7 @@ function SkeletonBase({ width = '100%', height, style }: SkeletonProps) {
             colors={shimmerColors}
             start={{ x: 0, y: 0.5 }}
             end={{ x: 1, y: 0.5 }}
-            style={{ width: containerWidth, height: '100%' }}
+            style={[styles.gradientFill, { width: containerWidth }]}
           />
         </Animated.View>
       )}
@@ -117,5 +112,11 @@ const styles = StyleSheet.create({
     padding: spacing.md,
     borderWidth: 1,
     overflow: 'hidden',
+  },
+  base: {
+    overflow: 'hidden',
+  },
+  gradientFill: {
+    height: '100%',
   },
 });

--- a/utils/__tests__/platform.test.ts
+++ b/utils/__tests__/platform.test.ts
@@ -262,6 +262,11 @@ describe('platform', () => {
       });
       const callback = jest.fn();
       addSystemThemeChangeListener(callback);
+      expect(capturedHandler).not.toBeNull();
+      // capturedHandler is set inside the addEventListener mock's closure above;
+      // TS can't narrow across that closure boundary (it would type this `never`
+      // after a guard), so the assertion above is the real non-null check.
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       capturedHandler!({ matches: true } as MediaQueryListEvent);
       expect(callback).toHaveBeenCalledWith(true);
     });

--- a/utils/metrics.test.ts
+++ b/utils/metrics.test.ts
@@ -31,36 +31,36 @@ describe('metrics.ts', () => {
 
       it('should calculate correct average for renewable share', () => {
         const result = calculateMetrics(sampleData);
-        expect(result).not.toBeNull();
-        expect(result!.renewable.avg).toBeCloseTo(55, 1); // (50+60+55)/3 = 55
+        if (!result) throw new Error('expected calculateMetrics result to be non-null');
+        expect(result.renewable.avg).toBeCloseTo(55, 1); // (50+60+55)/3 = 55
       });
 
       it('should calculate correct min/max for renewable share', () => {
         const result = calculateMetrics(sampleData);
-        expect(result).not.toBeNull();
-        expect(result!.renewable.min).toBe(50);
-        expect(result!.renewable.max).toBe(60);
+        if (!result) throw new Error('expected calculateMetrics result to be non-null');
+        expect(result.renewable.min).toBe(50);
+        expect(result.renewable.max).toBe(60);
       });
 
       it('should calculate correct average for market price (with 0.1 conversion)', () => {
         const result = calculateMetrics(sampleData);
-        expect(result).not.toBeNull();
+        if (!result) throw new Error('expected calculateMetrics result to be non-null');
         // (100*0.1 + 200*0.1 + 150*0.1) / 3 = 15
-        expect(result!.marketPrice.avg).toBeCloseTo(15, 1);
+        expect(result.marketPrice.avg).toBeCloseTo(15, 1);
       });
 
       it('should calculate correct min/max for market price (with 0.1 conversion)', () => {
         const result = calculateMetrics(sampleData);
-        expect(result).not.toBeNull();
-        expect(result!.marketPrice.min).toBeCloseTo(10, 1); // 100 * 0.1
-        expect(result!.marketPrice.max).toBeCloseTo(20, 1); // 200 * 0.1
+        if (!result) throw new Error('expected calculateMetrics result to be non-null');
+        expect(result.marketPrice.min).toBeCloseTo(10, 1); // 100 * 0.1
+        expect(result.marketPrice.max).toBeCloseTo(20, 1); // 200 * 0.1
       });
 
       it('should calculate correct time range', () => {
         const result = calculateMetrics(sampleData);
-        expect(result).not.toBeNull();
-        expect(result!.timeRange.start).toBe(Math.min(...sampleData.map(d => d.timestamp)));
-        expect(result!.timeRange.end).toBe(Math.max(...sampleData.map(d => d.timestamp)));
+        if (!result) throw new Error('expected calculateMetrics result to be non-null');
+        expect(result.timeRange.start).toBe(Math.min(...sampleData.map(d => d.timestamp)));
+        expect(result.timeRange.end).toBe(Math.max(...sampleData.map(d => d.timestamp)));
       });
     });
 
@@ -73,8 +73,8 @@ describe('metrics.ts', () => {
         ];
 
         const result = calculateMetrics(dataWithNulls);
-        expect(result).not.toBeNull();
-        expect(result!.renewable.avg).toBeCloseTo(55, 1); // (50+60)/2 = 55
+        if (!result) throw new Error('expected calculateMetrics result to be non-null');
+        expect(result.renewable.avg).toBeCloseTo(55, 1); // (50+60)/2 = 55
       });
 
       it('should ignore null market price values', () => {
@@ -85,8 +85,8 @@ describe('metrics.ts', () => {
         ];
 
         const result = calculateMetrics(dataWithNulls);
-        expect(result).not.toBeNull();
-        expect(result!.marketPrice.avg).toBeCloseTo(15, 1); // (100*0.1 + 200*0.1)/2 = 15
+        if (!result) throw new Error('expected calculateMetrics result to be non-null');
+        expect(result.marketPrice.avg).toBeCloseTo(15, 1); // (100*0.1 + 200*0.1)/2 = 15
       });
 
       it('should return 0 for avg/min/max when all renewable values are null', () => {
@@ -96,10 +96,10 @@ describe('metrics.ts', () => {
         ];
 
         const result = calculateMetrics(dataAllNull);
-        expect(result).not.toBeNull();
-        expect(result!.renewable.avg).toBe(0);
-        expect(result!.renewable.min).toBe(0);
-        expect(result!.renewable.max).toBe(0);
+        if (!result) throw new Error('expected calculateMetrics result to be non-null');
+        expect(result.renewable.avg).toBe(0);
+        expect(result.renewable.min).toBe(0);
+        expect(result.renewable.max).toBe(0);
       });
 
       it('should return 0 for avg/min/max when all market price values are null', () => {
@@ -109,10 +109,10 @@ describe('metrics.ts', () => {
         ];
 
         const result = calculateMetrics(dataAllNull);
-        expect(result).not.toBeNull();
-        expect(result!.marketPrice.avg).toBe(0);
-        expect(result!.marketPrice.min).toBe(0);
-        expect(result!.marketPrice.max).toBe(0);
+        if (!result) throw new Error('expected calculateMetrics result to be non-null');
+        expect(result.marketPrice.avg).toBe(0);
+        expect(result.marketPrice.min).toBe(0);
+        expect(result.marketPrice.max).toBe(0);
       });
     });
 
@@ -127,9 +127,10 @@ describe('metrics.ts', () => {
         ];
 
         const result = calculateMetrics(todayData);
-        expect(result).not.toBeNull();
-        expect(result!.today).toBeDefined();
-        expect(result!.today?.date).toBe(
+        if (!result) throw new Error('expected calculateMetrics result to be non-null');
+        expect(result.today).toBeDefined();
+        if (!result.today) throw new Error('expected today metrics to be defined');
+        expect(result.today?.date).toBe(
           now.toLocaleDateString('de-DE', { day: '2-digit', month: '2-digit', year: 'numeric' })
         );
       });
@@ -141,8 +142,8 @@ describe('metrics.ts', () => {
         ];
 
         const result = calculateMetrics(yesterdayData);
-        expect(result).not.toBeNull();
-        expect(result!.today).toBeUndefined();
+        if (!result) throw new Error('expected calculateMetrics result to be non-null');
+        expect(result.today).toBeUndefined();
       });
 
       it('should calculate end customer price correctly (market price + grid fees)', () => {
@@ -155,14 +156,15 @@ describe('metrics.ts', () => {
         ];
 
         const result = calculateMetrics(todayData);
-        expect(result).not.toBeNull();
-        expect(result!.today).toBeDefined();
+        if (!result) throw new Error('expected calculateMetrics result to be non-null');
+        expect(result.today).toBeDefined();
+        if (!result.today) throw new Error('expected today metrics to be defined');
 
         // Market price avg: (10+20)/2 = 15
         // End customer price avg: 15 + 20 = 35
-        expect(result!.today!.endCustomerPrice.avg).toBeCloseTo(15 + GRID_FEES_AND_TAXES, 1);
-        expect(result!.today!.endCustomerPrice.min).toBeCloseTo(10 + GRID_FEES_AND_TAXES, 1);
-        expect(result!.today!.endCustomerPrice.max).toBeCloseTo(20 + GRID_FEES_AND_TAXES, 1);
+        expect(result.today.endCustomerPrice.avg).toBeCloseTo(15 + GRID_FEES_AND_TAXES, 1);
+        expect(result.today.endCustomerPrice.min).toBeCloseTo(10 + GRID_FEES_AND_TAXES, 1);
+        expect(result.today.endCustomerPrice.max).toBeCloseTo(20 + GRID_FEES_AND_TAXES, 1);
       });
 
       it('should find current hour data within tolerance', () => {
@@ -173,10 +175,11 @@ describe('metrics.ts', () => {
         ];
 
         const result = calculateMetrics(currentData);
-        expect(result).not.toBeNull();
-        expect(result!.today).toBeDefined();
-        expect(result!.today!.renewable.current).toBe(55); // Should pick the closest one within tolerance
-        expect(result!.today!.marketPrice.current).toBeCloseTo(15, 1); // 150 * 0.1
+        if (!result) throw new Error('expected calculateMetrics result to be non-null');
+        expect(result.today).toBeDefined();
+        if (!result.today) throw new Error('expected today metrics to be defined');
+        expect(result.today.renewable.current).toBe(55); // Should pick the closest one within tolerance
+        expect(result.today.marketPrice.current).toBeCloseTo(15, 1); // 150 * 0.1
       });
 
       it('should return null for current values when no data within tolerance', () => {
@@ -189,11 +192,12 @@ describe('metrics.ts', () => {
         ];
 
         const result = calculateMetrics(oldData);
-        expect(result).not.toBeNull();
+        if (!result) throw new Error('expected calculateMetrics result to be non-null');
         // Data is from today, but outside 30-min tolerance for "current"
-        expect(result!.today).toBeDefined();
-        expect(result!.today!.renewable.current).toBeNull();
-        expect(result!.today!.marketPrice.current).toBeNull();
+        expect(result.today).toBeDefined();
+        if (!result.today) throw new Error('expected today metrics to be defined');
+        expect(result.today.renewable.current).toBeNull();
+        expect(result.today.marketPrice.current).toBeNull();
       });
     });
 
@@ -204,13 +208,13 @@ describe('metrics.ts', () => {
         ];
 
         const result = calculateMetrics(singleData);
-        expect(result).not.toBeNull();
-        expect(result!.renewable.avg).toBe(50);
-        expect(result!.renewable.min).toBe(50);
-        expect(result!.renewable.max).toBe(50);
-        expect(result!.marketPrice.avg).toBeCloseTo(10, 1);
-        expect(result!.marketPrice.min).toBeCloseTo(10, 1);
-        expect(result!.marketPrice.max).toBeCloseTo(10, 1);
+        if (!result) throw new Error('expected calculateMetrics result to be non-null');
+        expect(result.renewable.avg).toBe(50);
+        expect(result.renewable.min).toBe(50);
+        expect(result.renewable.max).toBe(50);
+        expect(result.marketPrice.avg).toBeCloseTo(10, 1);
+        expect(result.marketPrice.min).toBeCloseTo(10, 1);
+        expect(result.marketPrice.max).toBeCloseTo(10, 1);
       });
 
       it('should handle extreme values', () => {
@@ -220,13 +224,13 @@ describe('metrics.ts', () => {
         ];
 
         const result = calculateMetrics(extremeData);
-        expect(result).not.toBeNull();
-        expect(result!.renewable.avg).toBe(50);
-        expect(result!.renewable.min).toBe(0);
-        expect(result!.renewable.max).toBe(100);
-        expect(result!.marketPrice.avg).toBeCloseTo(50, 1); // (0+100)/2
-        expect(result!.marketPrice.min).toBe(0);
-        expect(result!.marketPrice.max).toBeCloseTo(100, 1);
+        if (!result) throw new Error('expected calculateMetrics result to be non-null');
+        expect(result.renewable.avg).toBe(50);
+        expect(result.renewable.min).toBe(0);
+        expect(result.renewable.max).toBe(100);
+        expect(result.marketPrice.avg).toBeCloseTo(50, 1); // (0+100)/2
+        expect(result.marketPrice.min).toBe(0);
+        expect(result.marketPrice.max).toBeCloseTo(100, 1);
       });
 
       it('should handle negative market prices (possible in energy markets)', () => {
@@ -236,10 +240,10 @@ describe('metrics.ts', () => {
         ];
 
         const result = calculateMetrics(negativeData);
-        expect(result).not.toBeNull();
-        expect(result!.marketPrice.avg).toBeCloseTo(0, 1); // (-10+10)/2
-        expect(result!.marketPrice.min).toBeCloseTo(-10, 1);
-        expect(result!.marketPrice.max).toBeCloseTo(10, 1);
+        if (!result) throw new Error('expected calculateMetrics result to be non-null');
+        expect(result.marketPrice.avg).toBeCloseTo(0, 1); // (-10+10)/2
+        expect(result.marketPrice.min).toBeCloseTo(-10, 1);
+        expect(result.marketPrice.max).toBeCloseTo(10, 1);
       });
 
       it('should handle data with regional renewable share', () => {
@@ -253,9 +257,9 @@ describe('metrics.ts', () => {
         ];
 
         const result = calculateMetrics(regionalData);
-        expect(result).not.toBeNull();
+        if (!result) throw new Error('expected calculateMetrics result to be non-null');
         // Should still use renewableShare for metrics (not regional)
-        expect(result!.renewable.avg).toBe(50);
+        expect(result.renewable.avg).toBe(50);
       });
 
       it('should handle data with interpolation flags', () => {
@@ -270,10 +274,10 @@ describe('metrics.ts', () => {
         ];
 
         const result = calculateMetrics(interpolatedData);
-        expect(result).not.toBeNull();
+        if (!result) throw new Error('expected calculateMetrics result to be non-null');
         // Interpolation flags should not affect metrics calculation
-        expect(result!.marketPrice.avg).toBeCloseTo(10, 1);
-        expect(result!.renewable.avg).toBe(50);
+        expect(result.marketPrice.avg).toBeCloseTo(10, 1);
+        expect(result.renewable.avg).toBe(50);
       });
     });
 


### PR DESCRIPTION
# Pull Request

## Beschreibung

Dritter Teil der Codepflege-Serie (nach #389, #390): die zwei verbliebenen offenen Punkte aus dem ursprünglichen Audit.

### 1. Alle 267 ESLint-Warnings behoben

**`no-non-null-assertion` (55, in 2 Testdateien):**
- `utils/metrics.test.ts`: `expect(result).not.toBeNull()` durch `if (!result) throw new Error(...)` ersetzt – TypeScript engt danach echt ein, alle `result!.x` werden zu `result.x`. Gleiches für die zweite Guard-Ebene `result.today`.
- `utils/__tests__/platform.test.ts`: eine verbleibende Assertion lässt sich nicht durch eine Closure-Grenze hindurch narrowen (der Wert wird im `addEventListener`-Mock gesetzt, TS würde danach fälschlich auf `never` engen) – dort bewusst mit begründetem `eslint-disable-next-line` stehen gelassen statt eine falsche Typisierung zu erzwingen.

**`react-native/no-inline-styles` (212, in 22 Dateien):** Die Regel flaggt jedes Style-Objekt-Literal, das mindestens einen Literal-Wert enthält (Zahl, String, Hex-Farbe) – auch gemischt mit dynamischen Werten in einem Array. Durchgängiges Muster:
- Rein statische Objekte → modul-weites `StyleSheet.create`.
- Gemischte Objekte (`{ fontSize: 11, color: colors.text }`) aufgeteilt: statischer Teil ins StyleSheet, nur der wirklich dynamische Rest bleibt inline im Array (`[styles.label, { color: colors.text }]`) – ein Objekt aus ausschließlich Member-Expressions/Identifiern ohne Literal wird von der Regel gar nicht mehr erkannt.
- Boolean-Ternarys mit zwei statischen Zweigen (`isPhone ? 17 : 20`) → zwei benannte Styles + Auswahl per Ternary zwischen den StyleSheet-Referenzen.
- `'#fff'` als aktive Toggle-Textfarbe wiederholt sich in 6 Dateien → jeweils zu einer benannten Modul-Konstante (`ACTIVE_*_TEXT_COLOR`) gemacht, da eine Identifier-Referenz im Ternary-Zweig reicht.
- `StyleSheet.absoluteFill` statt manuell wiederholtem `{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }`.
- `MetricsView.tsx`/`KpiCard.tsx`: `createStyles(colors, ...)` via `useMemo`, da dort *alle* Werte von Props abhängen.

**Verifikation:** Für jede Datei `tsc --noEmit` + `eslint` (0 Warnings) + volle Testsuite. Zusätzlich für die sechs größeren Refactorings (`MetricsView`, `PriceBarChart`, `RenewableBarChart`, `ChartSection`, `CorrelationScatterChart`, `ClockChart`) ein **Vorher/Nachher-Renderdiff** über `react-test-renderer`: Style-Arrays geflacht und Keys sortiert verglichen – die gerenderten Bäume sind danach byte-identisch. Reines Refactoring, keine Verhaltensänderung.

### 2. ClockChart-Komponententests (viertes, bisher ungetestetes Chart)

Gleiches Testmuster wie PR #390 für die drei anderen Chart-Primitive: Rendering ohne Crash, Guard-Klauseln (leerer Datensatz, jede Stunde ohne Preis, teilweise befüllt), Hover-Interaktion (Segment auswählen zeigt Preis, erneutes Verlassen versteckt ihn wieder – auf `Platform.OS === 'web'` läuft das über `onMouseEnter`/`onMouseLeave`, nicht `onPress`), vollständig interpolierte Stunde. 8 neue Tests.

## Art der Änderung

- [ ] Bugfix (non-breaking change)
- [ ] Neue Funktion (non-breaking change)
- [ ] Breaking Change (Fix oder Feature das bestehende Funktionalität ändert)
- [x] Dokumentation Update (nein, aber am ehesten passend: Test-/Lint-Aufräumarbeit ohne funktionale Änderung)

## Cross-Platform Kompatibilität

**Betrifft dieser PR plattformspezifischen Code?** Nein

Reine Style-Extraktion (StyleSheet statt Inline-Objekt) und Testergänzungen. Keine Änderung an `window.*`/`document`/`localStorage`-Zugriffen, keine neuen plattformabhängigen Codepfade.

## Testing Checklist

- [x] Keine TypeScript Errors (`npx tsc --noEmit` sauber)
- [x] Keine ESLint Errors/Warnings (`npx eslint .` → 0, vorher 267)
- [x] Testsuite grün: **26 Suiten / 314 Tests** (vorher 25 Suiten / 306 Tests)
- [x] Vorher/Nachher-Renderdiff für die 6 größeren Style-Refactorings: byte-identisch
- [ ] Lokaler Build (`npm run build:web`) – nicht ausgeführt
- [ ] Manuell auf Web/Android getestet – nicht ausgeführt, siehe Notizen

## Screenshots / Videos

Keine – der Renderdiff-Nachweis (siehe oben) ersetzt hier den visuellen Vergleich; es gibt keine beabsichtigte optische Änderung.

## Zusätzliche Notizen

**Was ich nicht verifizieren konnte:** Trotz des bestandenen Renderdiffs (React-Test-Renderer-Baum inkl. geflatteter Styles ist identisch) habe ich die App nicht im Browser/Emulator geöffnet. Der Renderdiff beweist, dass React Native exakt dieselben Style-Werte an die native/web-Rendering-Schicht übergibt – ein kurzer visueller Blick auf die Charts vor dem Merge ist trotzdem sinnvoll, insbesondere da dies die umfangreichste Änderung an diesen Dateien seit PR #389/#390 ist.

**Bewusst nicht in diesem PR:** Die 3 Tags aus der Git-History-Bereinigung (Issue #391) bleiben unverändert – separates, bereits dokumentiertes Thema.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LL9SZKyugnbvwGv3ng16TU)_