### PR TITLE
Fix #394: fetch.yml-Refresh-Loop nach Daten-Commits vermeiden

### DIFF
--- a/.github/workflows/deploy-unified.yml
+++ b/.github/workflows/deploy-unified.yml
@@ -218,9 +218,15 @@ jobs:
 
   # After a successful deploy to main, trigger a fresh data fetch
   # so marketdata.json is always up-to-date after releases/merges
+  # Skipped when the triggering push was itself a fetch.yml data commit — the
+  # data is already fresh, so re-dispatching fetch.yml here just adds a
+  # redundant run (Issue #394: this loop was a large share of fetch.yml's
+  # "manual" workflow_dispatch runs).
   refresh-data:
     needs: build-and-deploy
-    if: github.ref == 'refs/heads/main'
+    if: |
+      github.ref == 'refs/heads/main' &&
+      (github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'Update marketdata.json'))
     runs-on: ubuntu-latest
     steps:
       - name: Trigger fetch workflow


### PR DESCRIPTION
Restpunkt aus #394 (Maßnahmen A+B sind bereits in #395 auf `testing` gemerged).

## Befund

`deploy-unified.yml` löst im `refresh-data`-Job nach **jedem** erfolgreichen Deploy auf `main` einen `fetch.yml`-`workflow_dispatch` aus — auch dann, wenn der Deploy selbst durch einen von `fetch.yml` erzeugten Daten-Commit getriggert wurde:

```
fetch.yml (Cron) → Daten-Commit auf main → deploy-unified.yml (push-Trigger)
  → refresh-data-Job → fetch.yml (workflow_dispatch, redundant — Daten sind bereits frisch)
```

Das erklärt vermutlich einen Großteil der in #394 gemessenen 49/61 "manuellen" `fetch.yml`-Läufe (nur 12 waren tatsächlich Cron).

## Änderung

`refresh-data` überspringt den Re-Dispatch jetzt, wenn der auslösende Push-Commit mit `"Update marketdata.json"` beginnt (die Commit-Message, die `fetch.yml` selbst verwendet). Bei echten Code-Pushes, `schedule`- oder `workflow_dispatch`-Läufen bleibt das Verhalten unverändert — dort ist ein frischer Datenabgleich nach dem Deploy weiterhin sinnvoll.

## Nicht behoben (außerhalb Scope)

- **"Push on main" (44 min, dynamic/Copilot):** Kein Workflow in `.github/workflows/` triggert auf reinen `push: [main]` in diesem Muster. Vermutlich ein GitHub-internes "Pages build and deployment"-Workflow (Repo-Settings → Pages), keine Code-Änderung möglich. Sollte manuell in den Repo-Settings geprüft werden.
- **Maßnahme C** (Daten-Deploy vom App-Build trennen) bleibt bewusst in #396, siehe dort — größerer Umbau mit eigenem Testplan.

## Test plan

- [x] YAML-Syntax validiert (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-unified.yml'))"`)
- [ ] Nach Merge: nächster Fetch-Commit auf `main` löst Deploy aus, aber **kein** erneutes `fetch.yml`-Dispatch
- [ ] Ein echter Code-Push auf `main` löst weiterhin `refresh-data` → `fetch.yml` aus

---
_Generated by [Claude Code](https://claude.ai/code/session_01TmWW2hdVuuGdPaq8bVwt3Z)_